### PR TITLE
Fix npm step for auto format workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -23,7 +23,7 @@ jobs:
                   node-version: 20
                   cache: 'npm'
 
-            - run: npm ci
+            - run: npm install
 
             - run: make format
 


### PR DESCRIPTION
## Summary
- change `npm ci` to `npm install` in the auto-format workflow so it runs even if the lock file is out of sync

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889b53fb23483338eb8dd7bf6f2f50e