### PR TITLE
Add tests for remaining API store actions

### DIFF
--- a/tests/stores/api/store.test.ts
+++ b/tests/stores/api/store.test.ts
@@ -78,8 +78,74 @@ describe('useApiStore', () => {
 		expect(res).toEqual({ slug: 'a' });
 	});
 
-	it('handles single post errors', async () => {
-		client.get.mockRejectedValue(new Error('x'));
-		await expect(store.getPost('b')).rejects.toThrow('parsed');
-	});
+        it('handles single post errors', async () => {
+                client.get.mockRejectedValue(new Error('x'));
+                await expect(store.getPost('b')).rejects.toThrow('parsed');
+        });
+
+        it('gets experience', async () => {
+                client.get.mockResolvedValue({ exp: true });
+                const res = await store.getExperience();
+                expect(res).toEqual({ exp: true });
+        });
+
+        it('handles experience errors', async () => {
+                client.get.mockRejectedValue(new Error('fail'));
+                await expect(store.getExperience()).rejects.toThrow('parsed');
+        });
+
+        it('gets recommendations', async () => {
+                client.get.mockResolvedValue({ list: ['a'] });
+                const res = await store.getRecommendations();
+                expect(res).toEqual({ list: ['a'] });
+        });
+
+        it('handles recommendations errors', async () => {
+                client.get.mockRejectedValue(new Error('fail'));
+                await expect(store.getRecommendations()).rejects.toThrow('parsed');
+        });
+
+        it('gets projects', async () => {
+                client.get.mockResolvedValue({ list: [1] });
+                const res = await store.getProjects();
+                expect(res).toEqual({ list: [1] });
+        });
+
+        it('handles projects errors', async () => {
+                client.get.mockRejectedValue(new Error('fail'));
+                await expect(store.getProjects()).rejects.toThrow('parsed');
+        });
+
+        it('gets talks', async () => {
+                client.get.mockResolvedValue({ list: [] });
+                const res = await store.getTalks();
+                expect(res).toEqual({ list: [] });
+        });
+
+        it('handles talks errors', async () => {
+                client.get.mockRejectedValue(new Error('fail'));
+                await expect(store.getTalks()).rejects.toThrow('parsed');
+        });
+
+        it('gets social', async () => {
+                client.get.mockResolvedValue({ list: [] });
+                const res = await store.getSocial();
+                expect(res).toEqual({ list: [] });
+        });
+
+        it('handles social errors', async () => {
+                client.get.mockRejectedValue(new Error('fail'));
+                await expect(store.getSocial()).rejects.toThrow('parsed');
+        });
+
+        it('gets education', async () => {
+                client.get.mockResolvedValue({ list: [] });
+                const res = await store.getEducation();
+                expect(res).toEqual({ list: [] });
+        });
+
+        it('handles education errors', async () => {
+                client.get.mockRejectedValue(new Error('fail'));
+                await expect(store.getEducation()).rejects.toThrow('parsed');
+        });
 });


### PR DESCRIPTION
## Summary
- extend the `useApiStore` tests to cover all API actions

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889e6090754833381c5b9b3c2eb663f