### PR TITLE
Add Playwright e2e setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
 		"dev": "vite",
 		"build": "vite build",
 		"preview": "vite preview",
-		"test": "vitest run --coverage"
+                "test": "vitest run --coverage",
+                "e2e": "playwright test"
 	},
 	"dependencies": {
 		"dompurify": "^3.2.6",
@@ -43,6 +44,7 @@
 		"typescript": "^5.8.3",
 		"vite": "^6.3.5",
 		"vitest": "^3.2.0",
-		"vue-eslint-parser": "^10.2.0"
-	}
+                "vue-eslint-parser": "^10.2.0",
+                "@playwright/test": "^1.42.1"
+       }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  webServer: {
+    command: 'npm run dev',
+    port: 5173,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: 'http://localhost:5173',
+  },
+});

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('home page loads hero text', async ({ page }) => {
+  await page.goto('/');
+  await expect(
+    page.getByRole('heading', { level: 1, name: /I write about coding/i })
+  ).toBeVisible();
+});

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,8 +1,34 @@
 import { test, expect } from '@playwright/test';
 
-test('home page loads hero text', async ({ page }) => {
+test('home page loads all main sections', async ({ page }) => {
   await page.goto('/');
+
+  // Verify side navigation links
+  await expect(page.getByRole('link', { name: 'Home' })).toBeVisible();
+  await expect(page.getByRole('link', { name: 'About' })).toBeVisible();
+
+  // Header search box
+  await expect(page.getByLabel('Search')).toBeVisible();
+
+  // Hero section
   await expect(
-    page.getByRole('heading', { level: 1, name: /I write about coding/i })
+    page.getByRole('heading', {
+      level: 1,
+      name: /I write about coding, engineering, and leadership as a service\./i,
+    })
   ).toBeVisible();
+
+  // Content sections
+  await expect(
+    page.getByRole('heading', { level: 2, name: /Latest Articles/i })
+  ).toBeVisible();
+  await expect(
+    page.getByRole('heading', { level: 2, name: /Open-Source Projects/i })
+  ).toBeVisible();
+  await expect(
+    page.getByRole('heading', { level: 2, name: /Popular Talks/i })
+  ).toBeVisible();
+
+  // Footer
+  await expect(page.getByText(/Copyright/)).toBeVisible();
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,6 @@
 		},
 		"lib": ["esnext", "dom", "dom.iterable", "scripthost"]
 	},
-	"include": ["./src/**/*.ts", "./src/**/*.tsx", "./src/**/*.vue", "./src/**/*.d.ts", "./tests/**/*.ts", "./tests/**/*.tsx", "./vite.config.ts", "./tests/**/*.json"],
+        "include": ["./src/**/*.ts", "./src/**/*.tsx", "./src/**/*.vue", "./src/**/*.d.ts", "./tests/**/*.ts", "./tests/**/*.tsx", "./vite.config.ts", "./playwright.config.ts", "./tests/**/*.json"],
 	"exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Summary
- configure Playwright for e2e testing
- add `e2e` script
- write a simple home page test

## Testing
- `npm test` *(fails: vitest not found)*
- `npx playwright test` *(fails: cannot download playwright dependency)*

------
https://chatgpt.com/codex/tasks/task_e_688b35926d308333841f07eb13a212dc