### PR TITLE
chore: update vue to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
 				"lodash": "^4.17.21",
 				"marked": "^16.0.0",
 				"pinia": "^3.0.2",
-				"vue": "^3.5.13",
-				"vue-router": "^4.5.0"
-			},
+                                "vue": "^3.5.18",
+                                "vue-router": "^4.5.0"
+                        },
 			"devDependencies": {
 				"@babel/eslint-parser": "^7.27.0",
 				"@eslint/js": "^9.25.1",

--- a/package.json
+++ b/package.json
@@ -18,9 +18,9 @@
 		"lodash": "^4.17.21",
 		"marked": "^16.0.0",
 		"pinia": "^3.0.2",
-		"vue": "^3.5.13",
-		"vue-router": "^4.5.0"
-	},
+                "vue": "^3.5.18",
+                "vue-router": "^4.5.0"
+        },
 	"devDependencies": {
 		"@babel/eslint-parser": "^7.27.0",
 		"@eslint/js": "^9.25.1",


### PR DESCRIPTION
## Summary
- bump vue to the latest 3.5.18 release

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6899c8fde7988333a9cfe21f707fbba8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the core Vue dependency from ^3.5.13 to ^3.5.18.
  * Users may experience minor stability and performance improvements from upstream updates.
  * No changes to features, navigation, or UI behavior.
  * No configuration changes or user action required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->