### PR TITLE
chore: upgrade to Vite 7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
 				"@types/node": "^22.14.1",
 				"@typescript-eslint/eslint-plugin": "^8.38.0",
 				"@typescript-eslint/parser": "^8.38.0",
-				"@vitejs/plugin-vue": "^5.2.1",
+                                "@vitejs/plugin-vue": "^6.0.0",
 				"@vitest/coverage-v8": "^3.2.0",
 				"@vue/test-utils": "^2.4.1",
 				"eslint": "^9.31.0",
@@ -39,7 +39,7 @@
 				"rollup-plugin-visualizer": "^6.0.3",
 				"tailwindcss": "^4.1.4",
 				"typescript": "^5.8.3",
-				"vite": "^6.3.5",
+                                "vite": "^7.0.0",
 				"vitest": "^3.2.0",
 				"vue-eslint-parser": "^10.2.0"
 			},

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 		"@types/node": "^22.14.1",
 		"@typescript-eslint/eslint-plugin": "^8.38.0",
 		"@typescript-eslint/parser": "^8.38.0",
-		"@vitejs/plugin-vue": "^5.2.1",
+                "@vitejs/plugin-vue": "^6.0.0",
 		"@vitest/coverage-v8": "^3.2.0",
 		"@vue/test-utils": "^2.4.1",
 		"eslint": "^9.31.0",
@@ -44,7 +44,7 @@
 		"rollup-plugin-visualizer": "^6.0.3",
 		"tailwindcss": "^4.1.4",
 		"typescript": "^5.8.3",
-		"vite": "^6.3.5",
+                "vite": "^7.0.0",
 		"vitest": "^3.2.0",
 		"vue-eslint-parser": "^10.2.0"
 	}


### PR DESCRIPTION
## Summary
- update build tooling to Vite 7
- bump `@vitejs/plugin-vue` for compatibility with Vite 7

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/@vitejs%2fplugin-vue)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ad36356888333854fdebe14e03955