### PR TITLE
chore: align docker node version with package.json

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,7 +1,7 @@
 # --- Builder Stage ---
 # Use a standard Node.js image as the base for building the application.
 # This stage compiles your source code into static assets.
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 ARG VITE_API_ENV
 ARG VITE_API_URL


### PR DESCRIPTION
## Summary
- use Node 22 in Docker builder stage to match package.json engine

## Testing
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/vite)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ae184316c8333b64353339f9f5aca