### PR TITLE
test: update api client tests

### DIFF
--- a/tests/stores/api/client.test.ts
+++ b/tests/stores/api/client.test.ts
@@ -14,11 +14,11 @@ const url = 'http://example.com/';
 let client: ApiClient;
 
 beforeEach(() => {
-        vi.stubEnv('VITE_API_URL', url);
-        client = new ApiClient(options);
-        localStorage.clear();
-        vi.stubGlobal('fetch', vi.fn());
-        vi.spyOn(client as any, 'appendSignature').mockResolvedValue(undefined);
+	vi.stubEnv('VITE_API_URL', url);
+	client = new ApiClient(options);
+	localStorage.clear();
+	vi.stubGlobal('fetch', vi.fn());
+	vi.spyOn(client as any, 'appendSignature').mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -45,17 +45,17 @@ describe('ApiClient', () => {
 		expect(first).not.toBe(second);
 	});
 
-        it('handles post success and error responses', async () => {
-                const data = { ok: true };
-                (fetch as vi.Mock).mockResolvedValue(new Response(JSON.stringify(data), { status: 200 }));
+	it('handles post success and error responses', async () => {
+		const data = { ok: true };
+		(fetch as vi.Mock).mockResolvedValue(new Response(JSON.stringify(data), { status: 200 }));
 
-                const result = await client.post('test', { id: 1 });
-                expect(result).toEqual(data);
+		const result = await client.post('test', { id: 1 });
+		expect(result).toEqual(data);
 
-                (fetch as vi.Mock).mockResolvedValue(new Response('fail', { status: 500, statusText: 'err' }));
+		(fetch as vi.Mock).mockResolvedValue(new Response('fail', { status: 500, statusText: 'err' }));
 
-                await expect(client.post('test', { id: 2 })).rejects.toBeInstanceOf(HttpError);
-        });
+		await expect(client.post('test', { id: 2 })).rejects.toBeInstanceOf(HttpError);
+	});
 
 	it('caches get requests and serves from cache', async () => {
 		// prefill cache
@@ -64,9 +64,9 @@ describe('ApiClient', () => {
 
 		(fetch as vi.Mock).mockResolvedValue(new Response(null, { status: 304 }));
 
-                const result = await client.get('test');
-                expect(result).toEqual({ cached: true });
-        });
+		const result = await client.get('test');
+		expect(result).toEqual({ cached: true });
+	});
 
 	it('stores response with etag in cache', async () => {
 		const data = { foo: 'bar' };
@@ -77,14 +77,14 @@ describe('ApiClient', () => {
 			}),
 		);
 
-                const result = await client.get('test');
-                expect(result).toEqual(data);
-                expect(localStorage.getItem('api-cache-test')).not.toBeNull();
-        });
+		const result = await client.get('test');
+		expect(result).toEqual(data);
+		expect(localStorage.getItem('api-cache-test')).not.toBeNull();
+	});
 
 	it('throws HttpError on failed get', async () => {
 		(fetch as vi.Mock).mockResolvedValue(new Response('nope', { status: 404, statusText: 'NF' }));
 
-                await expect(client.get('oops')).rejects.toBeInstanceOf(HttpError);
-        });
+		await expect(client.get('oops')).rejects.toBeInstanceOf(HttpError);
+	});
 });

--- a/tests/stores/api/client.test.ts
+++ b/tests/stores/api/client.test.ts
@@ -12,14 +12,13 @@ const options: ApiClientOptions = {
 const url = 'http://example.com/';
 
 let client: ApiClient;
-let nonce: string;
 
 beforeEach(() => {
-	vi.stubEnv('VITE_API_URL', url);
-	client = new ApiClient(options);
-	nonce = 'nonce';
-	localStorage.clear();
-	vi.stubGlobal('fetch', vi.fn());
+        vi.stubEnv('VITE_API_URL', url);
+        client = new ApiClient(options);
+        localStorage.clear();
+        vi.stubGlobal('fetch', vi.fn());
+        vi.spyOn(client as any, 'appendSignature').mockResolvedValue(undefined);
 });
 
 afterEach(() => {
@@ -46,17 +45,17 @@ describe('ApiClient', () => {
 		expect(first).not.toBe(second);
 	});
 
-	it('handles post success and error responses', async () => {
-		const data = { ok: true };
-		(fetch as vi.Mock).mockResolvedValue(new Response(JSON.stringify(data), { status: 200 }));
+        it('handles post success and error responses', async () => {
+                const data = { ok: true };
+                (fetch as vi.Mock).mockResolvedValue(new Response(JSON.stringify(data), { status: 200 }));
 
-		const result = await client.post('test', nonce, { id: 1 });
-		expect(result).toEqual(data);
+                const result = await client.post('test', { id: 1 });
+                expect(result).toEqual(data);
 
-		(fetch as vi.Mock).mockResolvedValue(new Response('fail', { status: 500, statusText: 'err' }));
+                (fetch as vi.Mock).mockResolvedValue(new Response('fail', { status: 500, statusText: 'err' }));
 
-		await expect(client.post('test', nonce, { id: 2 })).rejects.toBeInstanceOf(HttpError);
-	});
+                await expect(client.post('test', { id: 2 })).rejects.toBeInstanceOf(HttpError);
+        });
 
 	it('caches get requests and serves from cache', async () => {
 		// prefill cache
@@ -65,9 +64,9 @@ describe('ApiClient', () => {
 
 		(fetch as vi.Mock).mockResolvedValue(new Response(null, { status: 304 }));
 
-		const result = await client.get('test', nonce);
-		expect(result).toEqual({ cached: true });
-	});
+                const result = await client.get('test');
+                expect(result).toEqual({ cached: true });
+        });
 
 	it('stores response with etag in cache', async () => {
 		const data = { foo: 'bar' };
@@ -78,14 +77,14 @@ describe('ApiClient', () => {
 			}),
 		);
 
-		const result = await client.get('test', nonce);
-		expect(result).toEqual(data);
-		expect(localStorage.getItem('api-cache-test')).not.toBeNull();
-	});
+                const result = await client.get('test');
+                expect(result).toEqual(data);
+                expect(localStorage.getItem('api-cache-test')).not.toBeNull();
+        });
 
 	it('throws HttpError on failed get', async () => {
 		(fetch as vi.Mock).mockResolvedValue(new Response('nope', { status: 404, statusText: 'NF' }));
 
-		await expect(client.get('oops', nonce)).rejects.toBeInstanceOf(HttpError);
-	});
+                await expect(client.get('oops')).rejects.toBeInstanceOf(HttpError);
+        });
 });

--- a/tests/stores/api/store.test.ts
+++ b/tests/stores/api/store.test.ts
@@ -34,117 +34,129 @@ describe('useApiStore', () => {
 		expect(store.searchTerm).toBe('vue');
 	});
 
-	it('boots in dev mode', () => {
-		const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
-		store.boot();
-		expect(spy).toHaveBeenCalledWith('API client booted ...');
-		spy.mockRestore();
-	});
+        it('boots in dev mode', () => {
+                const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+                store.boot();
+                expect(client.isDev).toHaveBeenCalled();
+                expect(spy).toHaveBeenCalledWith('API client booted ...');
+                spy.mockRestore();
+        });
 
-	it('gets profile', async () => {
-		client.get.mockResolvedValue({ data: { name: 'gus' } });
-		const res = await store.getProfile();
-		expect(res).toEqual({ data: { name: 'gus' } });
-	});
+        it('gets profile', async () => {
+                client.get.mockResolvedValue({ data: { name: 'gus' } });
+                const res = await store.getProfile();
+                expect(client.get).toHaveBeenCalledWith('profile');
+                expect(res).toEqual({ data: { name: 'gus' } });
+        });
 
 	it('handles profile errors', async () => {
 		client.get.mockRejectedValue(new Error('fail'));
 		await expect(store.getProfile()).rejects.toThrow('parsed');
 	});
 
-	it('gets categories', async () => {
-		client.get.mockResolvedValue({ list: [] });
-		const res = await store.getCategories();
-		expect(res).toEqual({ list: [] });
-	});
+        it('gets categories', async () => {
+                client.get.mockResolvedValue({ list: [] });
+                const res = await store.getCategories();
+                expect(client.get).toHaveBeenCalledWith('categories?limit=5');
+                expect(res).toEqual({ list: [] });
+        });
 
 	it('handles category errors', async () => {
 		client.get.mockRejectedValue(new Error('fail'));
 		await expect(store.getCategories()).rejects.toThrow('parsed');
 	});
 
-	it('gets posts', async () => {
-		client.post.mockResolvedValue({ list: [] });
-		const res = await store.getPosts({});
-		expect(res).toEqual({ list: [] });
-	});
+        it('gets posts', async () => {
+                const filters = {};
+                client.post.mockResolvedValue({ list: [] });
+                const res = await store.getPosts(filters);
+                expect(client.post).toHaveBeenCalledWith('posts?limit=5', filters);
+                expect(res).toEqual({ list: [] });
+        });
 
 	it('handles posts errors', async () => {
 		client.post.mockRejectedValue(new Error('nope'));
 		await expect(store.getPosts({})).rejects.toThrow('parsed');
 	});
 
-	it('gets single post', async () => {
-		client.get.mockResolvedValue({ slug: 'a' });
-		const res = await store.getPost('a');
-		expect(res).toEqual({ slug: 'a' });
-	});
+        it('gets single post', async () => {
+                client.get.mockResolvedValue({ slug: 'a' });
+                const res = await store.getPost('a');
+                expect(client.get).toHaveBeenCalledWith('posts/a');
+                expect(res).toEqual({ slug: 'a' });
+        });
 
 	it('handles single post errors', async () => {
 		client.get.mockRejectedValue(new Error('x'));
 		await expect(store.getPost('b')).rejects.toThrow('parsed');
 	});
 
-	it('gets experience', async () => {
-		client.get.mockResolvedValue({ exp: true });
-		const res = await store.getExperience();
-		expect(res).toEqual({ exp: true });
-	});
+        it('gets experience', async () => {
+                client.get.mockResolvedValue({ exp: true });
+                const res = await store.getExperience();
+                expect(client.get).toHaveBeenCalledWith('experience');
+                expect(res).toEqual({ exp: true });
+        });
 
 	it('handles experience errors', async () => {
 		client.get.mockRejectedValue(new Error('fail'));
 		await expect(store.getExperience()).rejects.toThrow('parsed');
 	});
 
-	it('gets recommendations', async () => {
-		client.get.mockResolvedValue({ list: ['a'] });
-		const res = await store.getRecommendations();
-		expect(res).toEqual({ list: ['a'] });
-	});
+        it('gets recommendations', async () => {
+                client.get.mockResolvedValue({ list: ['a'] });
+                const res = await store.getRecommendations();
+                expect(client.get).toHaveBeenCalledWith('recommendations');
+                expect(res).toEqual({ list: ['a'] });
+        });
 
 	it('handles recommendations errors', async () => {
 		client.get.mockRejectedValue(new Error('fail'));
 		await expect(store.getRecommendations()).rejects.toThrow('parsed');
 	});
 
-	it('gets projects', async () => {
-		client.get.mockResolvedValue({ list: [1] });
-		const res = await store.getProjects();
-		expect(res).toEqual({ list: [1] });
-	});
+        it('gets projects', async () => {
+                client.get.mockResolvedValue({ list: [1] });
+                const res = await store.getProjects();
+                expect(client.get).toHaveBeenCalledWith('projects');
+                expect(res).toEqual({ list: [1] });
+        });
 
 	it('handles projects errors', async () => {
 		client.get.mockRejectedValue(new Error('fail'));
 		await expect(store.getProjects()).rejects.toThrow('parsed');
 	});
 
-	it('gets talks', async () => {
-		client.get.mockResolvedValue({ list: [] });
-		const res = await store.getTalks();
-		expect(res).toEqual({ list: [] });
-	});
+        it('gets talks', async () => {
+                client.get.mockResolvedValue({ list: [] });
+                const res = await store.getTalks();
+                expect(client.get).toHaveBeenCalledWith('talks');
+                expect(res).toEqual({ list: [] });
+        });
 
 	it('handles talks errors', async () => {
 		client.get.mockRejectedValue(new Error('fail'));
 		await expect(store.getTalks()).rejects.toThrow('parsed');
 	});
 
-	it('gets social', async () => {
-		client.get.mockResolvedValue({ list: [] });
-		const res = await store.getSocial();
-		expect(res).toEqual({ list: [] });
-	});
+        it('gets social', async () => {
+                client.get.mockResolvedValue({ list: [] });
+                const res = await store.getSocial();
+                expect(client.get).toHaveBeenCalledWith('social');
+                expect(res).toEqual({ list: [] });
+        });
 
 	it('handles social errors', async () => {
 		client.get.mockRejectedValue(new Error('fail'));
 		await expect(store.getSocial()).rejects.toThrow('parsed');
 	});
 
-	it('gets education', async () => {
-		client.get.mockResolvedValue({ list: [] });
-		const res = await store.getEducation();
-		expect(res).toEqual({ list: [] });
-	});
+        it('gets education', async () => {
+                client.get.mockResolvedValue({ list: [] });
+                const res = await store.getEducation();
+                expect(client.get).toHaveBeenCalledWith('education');
+                expect(res).toEqual({ list: [] });
+        });
 
 	it('handles education errors', async () => {
 		client.get.mockRejectedValue(new Error('fail'));

--- a/tests/stores/api/store.test.ts
+++ b/tests/stores/api/store.test.ts
@@ -34,129 +34,129 @@ describe('useApiStore', () => {
 		expect(store.searchTerm).toBe('vue');
 	});
 
-        it('boots in dev mode', () => {
-                const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
-                store.boot();
-                expect(client.isDev).toHaveBeenCalled();
-                expect(spy).toHaveBeenCalledWith('API client booted ...');
-                spy.mockRestore();
-        });
+	it('boots in dev mode', () => {
+		const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+		store.boot();
+		expect(client.isDev).toHaveBeenCalled();
+		expect(spy).toHaveBeenCalledWith('API client booted ...');
+		spy.mockRestore();
+	});
 
-        it('gets profile', async () => {
-                client.get.mockResolvedValue({ data: { name: 'gus' } });
-                const res = await store.getProfile();
-                expect(client.get).toHaveBeenCalledWith('profile');
-                expect(res).toEqual({ data: { name: 'gus' } });
-        });
+	it('gets profile', async () => {
+		client.get.mockResolvedValue({ data: { name: 'gus' } });
+		const res = await store.getProfile();
+		expect(client.get).toHaveBeenCalledWith('profile');
+		expect(res).toEqual({ data: { name: 'gus' } });
+	});
 
 	it('handles profile errors', async () => {
 		client.get.mockRejectedValue(new Error('fail'));
 		await expect(store.getProfile()).rejects.toThrow('parsed');
 	});
 
-        it('gets categories', async () => {
-                client.get.mockResolvedValue({ list: [] });
-                const res = await store.getCategories();
-                expect(client.get).toHaveBeenCalledWith('categories?limit=5');
-                expect(res).toEqual({ list: [] });
-        });
+	it('gets categories', async () => {
+		client.get.mockResolvedValue({ list: [] });
+		const res = await store.getCategories();
+		expect(client.get).toHaveBeenCalledWith('categories?limit=5');
+		expect(res).toEqual({ list: [] });
+	});
 
 	it('handles category errors', async () => {
 		client.get.mockRejectedValue(new Error('fail'));
 		await expect(store.getCategories()).rejects.toThrow('parsed');
 	});
 
-        it('gets posts', async () => {
-                const filters = {};
-                client.post.mockResolvedValue({ list: [] });
-                const res = await store.getPosts(filters);
-                expect(client.post).toHaveBeenCalledWith('posts?limit=5', filters);
-                expect(res).toEqual({ list: [] });
-        });
+	it('gets posts', async () => {
+		const filters = {};
+		client.post.mockResolvedValue({ list: [] });
+		const res = await store.getPosts(filters);
+		expect(client.post).toHaveBeenCalledWith('posts?limit=5', filters);
+		expect(res).toEqual({ list: [] });
+	});
 
 	it('handles posts errors', async () => {
 		client.post.mockRejectedValue(new Error('nope'));
 		await expect(store.getPosts({})).rejects.toThrow('parsed');
 	});
 
-        it('gets single post', async () => {
-                client.get.mockResolvedValue({ slug: 'a' });
-                const res = await store.getPost('a');
-                expect(client.get).toHaveBeenCalledWith('posts/a');
-                expect(res).toEqual({ slug: 'a' });
-        });
+	it('gets single post', async () => {
+		client.get.mockResolvedValue({ slug: 'a' });
+		const res = await store.getPost('a');
+		expect(client.get).toHaveBeenCalledWith('posts/a');
+		expect(res).toEqual({ slug: 'a' });
+	});
 
 	it('handles single post errors', async () => {
 		client.get.mockRejectedValue(new Error('x'));
 		await expect(store.getPost('b')).rejects.toThrow('parsed');
 	});
 
-        it('gets experience', async () => {
-                client.get.mockResolvedValue({ exp: true });
-                const res = await store.getExperience();
-                expect(client.get).toHaveBeenCalledWith('experience');
-                expect(res).toEqual({ exp: true });
-        });
+	it('gets experience', async () => {
+		client.get.mockResolvedValue({ exp: true });
+		const res = await store.getExperience();
+		expect(client.get).toHaveBeenCalledWith('experience');
+		expect(res).toEqual({ exp: true });
+	});
 
 	it('handles experience errors', async () => {
 		client.get.mockRejectedValue(new Error('fail'));
 		await expect(store.getExperience()).rejects.toThrow('parsed');
 	});
 
-        it('gets recommendations', async () => {
-                client.get.mockResolvedValue({ list: ['a'] });
-                const res = await store.getRecommendations();
-                expect(client.get).toHaveBeenCalledWith('recommendations');
-                expect(res).toEqual({ list: ['a'] });
-        });
+	it('gets recommendations', async () => {
+		client.get.mockResolvedValue({ list: ['a'] });
+		const res = await store.getRecommendations();
+		expect(client.get).toHaveBeenCalledWith('recommendations');
+		expect(res).toEqual({ list: ['a'] });
+	});
 
 	it('handles recommendations errors', async () => {
 		client.get.mockRejectedValue(new Error('fail'));
 		await expect(store.getRecommendations()).rejects.toThrow('parsed');
 	});
 
-        it('gets projects', async () => {
-                client.get.mockResolvedValue({ list: [1] });
-                const res = await store.getProjects();
-                expect(client.get).toHaveBeenCalledWith('projects');
-                expect(res).toEqual({ list: [1] });
-        });
+	it('gets projects', async () => {
+		client.get.mockResolvedValue({ list: [1] });
+		const res = await store.getProjects();
+		expect(client.get).toHaveBeenCalledWith('projects');
+		expect(res).toEqual({ list: [1] });
+	});
 
 	it('handles projects errors', async () => {
 		client.get.mockRejectedValue(new Error('fail'));
 		await expect(store.getProjects()).rejects.toThrow('parsed');
 	});
 
-        it('gets talks', async () => {
-                client.get.mockResolvedValue({ list: [] });
-                const res = await store.getTalks();
-                expect(client.get).toHaveBeenCalledWith('talks');
-                expect(res).toEqual({ list: [] });
-        });
+	it('gets talks', async () => {
+		client.get.mockResolvedValue({ list: [] });
+		const res = await store.getTalks();
+		expect(client.get).toHaveBeenCalledWith('talks');
+		expect(res).toEqual({ list: [] });
+	});
 
 	it('handles talks errors', async () => {
 		client.get.mockRejectedValue(new Error('fail'));
 		await expect(store.getTalks()).rejects.toThrow('parsed');
 	});
 
-        it('gets social', async () => {
-                client.get.mockResolvedValue({ list: [] });
-                const res = await store.getSocial();
-                expect(client.get).toHaveBeenCalledWith('social');
-                expect(res).toEqual({ list: [] });
-        });
+	it('gets social', async () => {
+		client.get.mockResolvedValue({ list: [] });
+		const res = await store.getSocial();
+		expect(client.get).toHaveBeenCalledWith('social');
+		expect(res).toEqual({ list: [] });
+	});
 
 	it('handles social errors', async () => {
 		client.get.mockRejectedValue(new Error('fail'));
 		await expect(store.getSocial()).rejects.toThrow('parsed');
 	});
 
-        it('gets education', async () => {
-                client.get.mockResolvedValue({ list: [] });
-                const res = await store.getEducation();
-                expect(client.get).toHaveBeenCalledWith('education');
-                expect(res).toEqual({ list: [] });
-        });
+	it('gets education', async () => {
+		client.get.mockResolvedValue({ list: [] });
+		const res = await store.getEducation();
+		expect(client.get).toHaveBeenCalledWith('education');
+		expect(res).toEqual({ list: [] });
+	});
 
 	it('handles education errors', async () => {
 		client.get.mockRejectedValue(new Error('fail'));


### PR DESCRIPTION
## Summary
- update API client tests for new client.get/post signatures
- stub appendSignature to avoid network calls

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68be392abf7c8333ac60ae9be3e03a7a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - No user-facing changes in this release.

- Refactor
  - Simplified request handling to remove a redundant request parameter; behavior unchanged for users.

- Tests
  - Updated test suite to match the simplified request flow and improve coverage for caching, success/error, and 304/ETag cases.
  - Added test spies/mocks to verify signing is invoked without altering outcomes.
  - Tightened integration tests to validate exact endpoint calls and parameter forwarding.
  - Minor test formatting/indentation cleanups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->