### PR TITLE
chore: bump vite to 7.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
 				"rollup-plugin-visualizer": "^6.0.3",
 				"tailwindcss": "^4.1.4",
 				"typescript": "^5.8.3",
-				"vite": "^7.0.0",
+                                "vite": "^7.1.5",
 				"vitest": "^3.2.0",
 				"vue-eslint-parser": "^10.2.0"
 			},
@@ -6285,10 +6285,9 @@
 			}
 		},
 		"node_modules/vite": {
-			"version": "7.1.4",
-			"resolved": "https://registry.npmjs.org/vite/-/vite-7.1.4.tgz",
-			"integrity": "sha512-X5QFK4SGynAeeIt+A7ZWnApdUyHYm+pzv/8/A57LqSGcI88U6R6ipOs3uCesdc6yl7nl+zNO0t8LmqAdXcQihw==",
-			"dev": true,
+                        "version": "7.1.5",
+                        "resolved": "https://registry.npmjs.org/vite/-/vite-7.1.5.tgz",
+                        "dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"esbuild": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
 		"rollup-plugin-visualizer": "^6.0.3",
 		"tailwindcss": "^4.1.4",
 		"typescript": "^5.8.3",
-		"vite": "^7.0.0",
+                "vite": "^7.1.5",
 		"vitest": "^3.2.0",
 		"vue-eslint-parser": "^10.2.0"
 	}


### PR DESCRIPTION
## Summary
- bump vite to 7.1.5 addressing security advisories

## Testing
- `npm test` *(fails: sh: 1: vitest: not found)*


------
https://chatgpt.com/codex/tasks/task_e_68bfa49da0a08333afada9998dd614dd