### PR TITLE
ci: add deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,60 @@
+name: Deploy
+
+on:
+    push:
+        branches:
+            - main
+    workflow_dispatch:
+
+concurrency:
+    group: deploy
+    cancel-in-progress: true
+
+permissions:
+    contents: read
+    id-token: write
+
+jobs:
+    deploy:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: docker/setup-buildx-action@v3
+
+            - name: Log in to GitHub Container Registry
+              uses: docker/login-action@v3
+              with:
+                  registry: ghcr.io
+                  username: ${{ github.actor }}
+                  password: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Build and push builder image
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  file: docker/Dockerfile
+                  target: builder
+                  push: true
+                  tags: ghcr.io/${{ github.repository_owner }}/web/app-builder-image:${{ github.sha }}
+
+            - name: Build and push production image
+              uses: docker/build-push-action@v6
+              with:
+                  context: .
+                  file: docker/Dockerfile
+                  push: true
+                  tags: ghcr.io/${{ github.repository_owner }}/web/web-prod-builder:${{ github.sha }}
+                  build-args: |
+                      BUILDER_IMAGE=ghcr.io/${{ github.repository_owner }}/web/app-builder-image:${{ github.sha }}
+
+            - name: Deploy via SSH
+              uses: appleboy/ssh-action@v1.0.3
+              with:
+                  host: ${{ secrets.DEPLOY_HOST }}
+                  username: ${{ secrets.DEPLOY_USER }}
+                  key: ${{ secrets.SSH_PRIVATE_KEY }}
+                  script: |
+                      cd ${{ secrets.DEPLOY_PATH }}
+                      docker compose pull
+                      docker compose up -d


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy Docker images via SSH

## Testing
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bfbb6c85a483338c20e8204d383160