### PR TITLE
Integrate SEO utilities with Vue

### DIFF
--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -81,7 +81,7 @@
 
 <script setup lang="ts">
 import { computed, ref, onMounted } from 'vue';
-import { seo, SITE_NAME } from '@/support/seo';
+import { useSeo, SITE_NAME } from '@/support/seo';
 import AboutPicture from '@images/profile/about.jpg';
 import FooterPartial from '@partials/FooterPartial.vue';
 import HeaderPartial from '@partials/HeaderPartial.vue';
@@ -107,10 +107,10 @@ const formattedNickname = computed((): string => {
 	return str.charAt(0).toUpperCase() + str.slice(1);
 });
 
-seo.apply({
-	title: 'About',
-	description: `${SITE_NAME} is an engineering leader who’s passionate about building reliable and smooth software.`,
-	image: AboutPicture,
+useSeo({
+        title: 'About',
+        description: `${SITE_NAME} is an engineering leader who’s passionate about building reliable and smooth software.`,
+        image: AboutPicture,
 });
 
 onMounted(async () => {

--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -53,16 +53,16 @@ import { onMounted, ref } from 'vue';
 import { useApiStore } from '@api/store.ts';
 import { debugError } from '@api/http-error.ts';
 import type { ProfileResponse } from '@api/response/index.ts';
-import { seo, SITE_NAME } from '@/support/seo';
+import { useSeo, SITE_NAME } from '@/support/seo';
 import ogImage from '@images/profile/about.jpg';
 
 const apiStore = useApiStore();
 const profile = ref<ProfileResponse | null>(null);
 
-seo.apply({
-	title: 'Home',
-	description: `${SITE_NAME} is a full-stack Software Engineer leader & architect with over two decades of experience in building complex web systems and products.`,
-	image: ogImage,
+useSeo({
+        title: 'Home',
+        description: `${SITE_NAME} is a full-stack Software Engineer leader & architect with over two decades of experience in building complex web systems and products.`,
+        image: ogImage,
 });
 
 onMounted(async () => {

--- a/src/pages/PostPage.vue
+++ b/src/pages/PostPage.vue
@@ -114,7 +114,7 @@
 <script setup lang="ts">
 import { marked } from 'marked';
 import DOMPurify from 'dompurify';
-import { seo } from '@/support/seo';
+import { useSeoFromPost } from '@/support/seo';
 import { useRoute } from 'vue-router';
 import { useApiStore } from '@api/store.ts';
 import { useDarkMode } from '@/dark-mode.ts';
@@ -136,9 +136,11 @@ const post = ref<PostResponse>();
 const slug = ref<string>(route.params.slug as string);
 const postContainer = ref<HTMLElement | null>(null);
 
+useSeoFromPost(post);
+
 marked.use({
-	breaks: true,
-	gfm: true,
+        breaks: true,
+        gfm: true,
 });
 
 const htmlContent = computed(() => {
@@ -195,11 +197,7 @@ onMounted(async () => {
 	await initializeHighlighter(highlight);
 
 	try {
-		post.value = (await apiStore.getPost(slug.value)) as PostResponse;
-
-		if (post.value) {
-			seo.applyFromPost(post.value);
-		}
+                post.value = (await apiStore.getPost(slug.value)) as PostResponse;
 	} catch (error) {
 		debugError(error);
 	}

--- a/src/pages/ProjectsPage.vue
+++ b/src/pages/ProjectsPage.vue
@@ -58,7 +58,7 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue';
 import { useApiStore } from '@api/store.ts';
-import { seo, SITE_NAME } from '@/support/seo';
+import { useSeo, SITE_NAME } from '@/support/seo';
 import ogImage from '@images/profile/about.jpg';
 import { debugError } from '@api/http-error.ts';
 import FooterPartial from '@partials/FooterPartial.vue';
@@ -73,10 +73,10 @@ const apiStore = useApiStore();
 const projects = ref<ProjectsResponse[]>([]);
 const profile = ref<ProfileResponse | null>(null);
 
-seo.apply({
-	title: 'Projects',
-	description: `Explore some of ${SITE_NAME} open source and client projects built to solve real engineering challenges.`,
-	image: ogImage,
+useSeo({
+        title: 'Projects',
+        description: `Explore some of ${SITE_NAME} open source and client projects built to solve real engineering challenges.`,
+        image: ogImage,
 });
 
 onMounted(async () => {

--- a/src/pages/ResumePage.vue
+++ b/src/pages/ResumePage.vue
@@ -54,7 +54,7 @@ import RecommendationPartial from '@partials/RecommendationPartial.vue';
 
 import { ref, onMounted } from 'vue';
 import { useApiStore } from '@api/store.ts';
-import { seo, SITE_NAME } from '@/support/seo';
+import { useSeo, SITE_NAME } from '@/support/seo';
 import ogImage from '@images/profile/about.jpg';
 import { debugError } from '@api/http-error.ts';
 import type { ProfileResponse, EducationResponse, ExperienceResponse, RecommendationsResponse } from '@api/response/index.ts';
@@ -65,10 +65,10 @@ const education = ref<EducationResponse[] | null>(null);
 const experience = ref<ExperienceResponse[] | null>(null);
 const recommendations = ref<RecommendationsResponse[] | null>(null);
 
-seo.apply({
-	title: 'Resume',
-	description: `Explore the experience, education, and recommendations of ${SITE_NAME}.`,
-	image: ogImage,
+useSeo({
+        title: 'Resume',
+        description: `Explore the experience, education, and recommendations of ${SITE_NAME}.`,
+        image: ogImage,
 });
 
 onMounted(async () => {

--- a/src/pages/SubscribePage.vue
+++ b/src/pages/SubscribePage.vue
@@ -159,16 +159,16 @@
 </template>
 
 <script setup lang="ts">
-import { seo, SITE_NAME } from '@/support/seo';
+import { useSeo, SITE_NAME } from '@/support/seo';
 import ogImage from '@images/profile/about.jpg';
 import HeaderPartial from '@partials/HeaderPartial.vue';
 import FooterPartial from '@partials/FooterPartial.vue';
 import SideNavPartial from '@partials/SideNavPartial.vue';
 import WidgetSponsorPartial from '@partials/WidgetSponsorPartial.vue';
 
-seo.apply({
-	title: 'Subscribe',
-	description: `Subscribe to ${SITE_NAME}'s newsletter to updates of articles and cool things he is working on.`,
-	image: ogImage,
+useSeo({
+        title: 'Subscribe',
+        description: `Subscribe to ${SITE_NAME}'s newsletter to updates of articles and cool things he is working on.`,
+        image: ogImage,
 });
 </script>

--- a/src/support/seo.ts
+++ b/src/support/seo.ts
@@ -1,3 +1,4 @@
+import { computed, onBeforeUnmount, unref, watchEffect, type MaybeRefOrGetter } from 'vue';
 import type { PostResponse } from '@api/response/posts-response.ts';
 
 export const DEFAULT_SITE_URL = 'https://oullin.io'
@@ -36,13 +37,18 @@ interface SeoOptions {
 	jsonLd?: Record<string, unknown>;
 }
 
+const hasDocument = typeof document !== 'undefined';
+const hasWindow = typeof window !== 'undefined';
+
 export class Seo {
-	apply(options: SeoOptions): void {
-		const currentPath = window.location.pathname + window.location.search;
-		const url = options.url ?? new URL(currentPath, SITE_URL).toString();
-		const image = options.image ? new URL(options.image, SITE_URL).toString() : undefined;
-		const title = options.title ? `${options.title} - ${SITE_NAME}` : SITE_NAME;
-		const description = options.description;
+        apply(options: SeoOptions): void {
+                if (!hasDocument || !hasWindow) return;
+
+                const currentPath = window.location.pathname + window.location.search;
+                const url = options.url ?? new URL(currentPath, SITE_URL).toString();
+                const image = options.image ? new URL(options.image, SITE_URL).toString() : undefined;
+                const title = options.title ? `${options.title} - ${SITE_NAME}` : SITE_NAME;
+                const description = options.description;
 
 		document.title = title;
 
@@ -100,12 +106,13 @@ export class Seo {
 		});
 	}
 
-	private setMetaByName(name: string, content?: string): void {
-		if (!content) return;
+        private setMetaByName(name: string, content?: string): void {
+                if (!hasDocument) return;
+                if (!content) return;
 
-		let element = document.head.querySelector<HTMLMetaElement>(`meta[name="${name}"]`);
+                let element = document.head.querySelector<HTMLMetaElement>(`meta[name="${name}"]`);
 
-		if (!element) {
+                if (!element) {
 			element = document.createElement('meta');
 			element.setAttribute('name', name);
 
@@ -115,34 +122,37 @@ export class Seo {
 		element.setAttribute('content', content);
 	}
 
-	private setMetaByProperty(property: string, content?: string): void {
-		if (!content) return;
-		let element = document.head.querySelector<HTMLMetaElement>(`meta[property="${property}"]`);
-		if (!element) {
-			element = document.createElement('meta');
-			element.setAttribute('property', property);
+        private setMetaByProperty(property: string, content?: string): void {
+                if (!hasDocument) return;
+                if (!content) return;
+                let element = document.head.querySelector<HTMLMetaElement>(`meta[property="${property}"]`);
+                if (!element) {
+                        element = document.createElement('meta');
+                        element.setAttribute('property', property);
 			document.head.appendChild(element);
 		}
 		element.setAttribute('content', content);
 	}
 
-	private setLink(rel: string, href?: string): void {
-		if (!href) return;
-		let element = document.head.querySelector<HTMLLinkElement>(`link[rel="${rel}"]`);
-		if (!element) {
-			element = document.createElement('link');
-			element.setAttribute('rel', rel);
+        private setLink(rel: string, href?: string): void {
+                if (!hasDocument) return;
+                if (!href) return;
+                let element = document.head.querySelector<HTMLLinkElement>(`link[rel="${rel}"]`);
+                if (!element) {
+                        element = document.createElement('link');
+                        element.setAttribute('rel', rel);
 			document.head.appendChild(element);
 		}
 		element.setAttribute('href', href);
 	}
 
-	private setJsonLd(data?: Record<string, unknown>): void {
-		const id = 'seo-jsonld';
-		let script = document.getElementById(id) as HTMLScriptElement | null;
-		if (!data) {
-			if (script) script.remove();
-			return;
+        private setJsonLd(data?: Record<string, unknown>): void {
+                if (!hasDocument) return;
+                const id = 'seo-jsonld';
+                let script = document.getElementById(id) as HTMLScriptElement | null;
+                if (!data) {
+                        if (script) script.remove();
+                        return;
 		}
 		const json = JSON.stringify(data);
 		if (!script) {
@@ -181,3 +191,53 @@ export class Seo {
 }
 
 export const seo = new Seo();
+
+function resolveValue<T>(value: MaybeRefOrGetter<T>): T {
+        return typeof value === 'function' ? (value as () => T)() : unref(value);
+}
+
+export function useSeo(options: MaybeRefOrGetter<SeoOptions | null | undefined>): void {
+        if (!hasDocument || !hasWindow) return;
+
+        const stop = watchEffect(() => {
+                const resolved = resolveValue(options);
+
+                if (!resolved) return;
+
+                seo.apply(resolved);
+        });
+
+        onBeforeUnmount(() => {
+                stop();
+        });
+}
+
+export function useSeoFromPost(post: MaybeRefOrGetter<PostResponse | null | undefined>): void {
+        const seoOptions = computed<SeoOptions | undefined>(() => {
+                const value = resolveValue(post);
+
+                if (!value) return undefined;
+
+                return {
+                        title: value.title,
+                        description: value.excerpt,
+                        image: value.cover_image_url,
+                        type: 'article',
+                        url: new URL(`/posts/${value.slug}`, SITE_URL).toString(),
+                        jsonLd: {
+                                '@context': 'https://schema.org',
+                                '@type': 'Article',
+                                headline: value.title,
+                                description: value.excerpt,
+                                image: value.cover_image_url,
+                                datePublished: value.published_at,
+                                author: {
+                                        '@type': 'Person',
+                                        name: SITE_NAME,
+                                },
+                        },
+                } satisfies SeoOptions;
+        });
+
+        useSeo(seoOptions);
+}


### PR DESCRIPTION
## Summary
- add Vue composition helpers that apply SEO metadata reactively and guard DOM access when rendering outside the browser
- update the static page components to call the new helpers so their metadata stays in sync with Vue state
- switch the post detail page to the reactive helper so post-specific metadata is written once the API response arrives

## Testing
- npm run test *(fails: vitest: not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8e29da33c83338bd15003f0aae7a3