### PR TITLE
Strip front matter before rendering markdown

### DIFF
--- a/src/pages/PostPage.vue
+++ b/src/pages/PostPage.vue
@@ -139,11 +139,11 @@ const postContainer = ref<HTMLElement | null>(null);
 useSeoFromPost(post);
 
 const htmlContent = computed(() => {
-        if (post.value && post.value.content) {
-                return DOMPurify.sanitize(renderMarkdown(post.value.content));
-        }
+	if (post.value && post.value.content) {
+		return DOMPurify.sanitize(renderMarkdown(post.value.content));
+	}
 
-        return '';
+	return '';
 });
 
 const xURLFor = (post: PostResponse) => {

--- a/src/pages/PostPage.vue
+++ b/src/pages/PostPage.vue
@@ -112,7 +112,6 @@
 </template>
 
 <script setup lang="ts">
-import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import { siteUrlFor, useSeoFromPost } from '@/support/seo';
 import { useRoute } from 'vue-router';
@@ -126,6 +125,7 @@ import SideNavPartial from '@partials/SideNavPartial.vue';
 import type { PostResponse } from '@api/response/index.ts';
 import WidgetSponsorPartial from '@partials/WidgetSponsorPartial.vue';
 import { date, getReadingTime, initializeHighlighter } from '@/public.ts';
+import { renderMarkdown } from '@/support/markdown.ts';
 import { onMounted, ref, computed, watch, nextTick, watchEffect } from 'vue';
 
 // --- Component
@@ -138,17 +138,12 @@ const postContainer = ref<HTMLElement | null>(null);
 
 useSeoFromPost(post);
 
-marked.use({
-	breaks: true,
-	gfm: true,
-});
-
 const htmlContent = computed(() => {
-	if (post.value && post.value.content) {
-		return DOMPurify.sanitize(marked.parse(post.value.content) as string);
-	}
+        if (post.value && post.value.content) {
+                return DOMPurify.sanitize(renderMarkdown(post.value.content));
+        }
 
-	return '';
+        return '';
 });
 
 const xURLFor = (post: PostResponse) => {

--- a/src/partials/EducationPartial.vue
+++ b/src/partials/EducationPartial.vue
@@ -40,9 +40,9 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
-import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import { EducationResponse } from '@api/response/index.ts';
+import { renderMarkdown } from '@/support/markdown.ts';
 
 const { education } = defineProps<{
 	education: Array<EducationResponse>;
@@ -50,7 +50,7 @@ const { education } = defineProps<{
 
 const processedEducation = computed(() => {
 	return education.map((item) => {
-		const sanitisedHtml = DOMPurify.sanitize(marked.parse(item.description) as string);
+                const sanitisedHtml = DOMPurify.sanitize(renderMarkdown(item.description));
 
 		return {
 			...item,

--- a/src/partials/EducationPartial.vue
+++ b/src/partials/EducationPartial.vue
@@ -50,7 +50,7 @@ const { education } = defineProps<{
 
 const processedEducation = computed(() => {
 	return education.map((item) => {
-                const sanitisedHtml = DOMPurify.sanitize(renderMarkdown(item.description));
+		const sanitisedHtml = DOMPurify.sanitize(renderMarkdown(item.description));
 
 		return {
 			...item,

--- a/src/partials/RecommendationPartial.vue
+++ b/src/partials/RecommendationPartial.vue
@@ -28,27 +28,22 @@
 
 <script setup lang="ts">
 import { computed } from 'vue';
-import { marked } from 'marked';
 import DOMPurify from 'dompurify';
 import { image, date } from '@/public.ts';
 import type { RecommendationsResponse } from '@api/response/recommendations-response.ts';
-
-marked.use({
-	breaks: true,
-	gfm: true,
-});
+import { renderMarkdown } from '@/support/markdown.ts';
 
 const { recommendations } = defineProps<{
-	recommendations: Array<RecommendationsResponse>;
+        recommendations: Array<RecommendationsResponse>;
 }>();
 
 const processedRecommendations = computed(() => {
-	return recommendations.map((item) => {
-		const sanitisedHtml = DOMPurify.sanitize(marked.parse(item.text) as string);
+        return recommendations.map((item) => {
+                const sanitisedHtml = DOMPurify.sanitize(renderMarkdown(item.text));
 
-		return {
-			...item,
-			html: sanitisedHtml,
+                return {
+                        ...item,
+                        html: sanitisedHtml,
 			formattedDate: date().format(new Date(item.created_at)),
 		};
 	});

--- a/src/partials/RecommendationPartial.vue
+++ b/src/partials/RecommendationPartial.vue
@@ -34,16 +34,16 @@ import type { RecommendationsResponse } from '@api/response/recommendations-resp
 import { renderMarkdown } from '@/support/markdown.ts';
 
 const { recommendations } = defineProps<{
-        recommendations: Array<RecommendationsResponse>;
+	recommendations: Array<RecommendationsResponse>;
 }>();
 
 const processedRecommendations = computed(() => {
-        return recommendations.map((item) => {
-                const sanitisedHtml = DOMPurify.sanitize(renderMarkdown(item.text));
+	return recommendations.map((item) => {
+		const sanitisedHtml = DOMPurify.sanitize(renderMarkdown(item.text));
 
-                return {
-                        ...item,
-                        html: sanitisedHtml,
+		return {
+			...item,
+			html: sanitisedHtml,
 			formattedDate: date().format(new Date(item.created_at)),
 		};
 	});

--- a/src/support/markdown.ts
+++ b/src/support/markdown.ts
@@ -3,26 +3,26 @@ import { marked } from 'marked';
 const FRONT_MATTER_REGEX = /^(?:\uFEFF)?---\s*[\r\n]+([\s\S]*?)\r?\n---\s*[\r\n]*/m;
 
 marked.setOptions({
-        breaks: true,
-        gfm: true,
+	breaks: true,
+	gfm: true,
 });
 
 function stripFrontMatter(markdown: string): string {
-        if (!markdown.trimStart().startsWith('---')) {
-                return markdown;
-        }
+	if (!markdown.trimStart().startsWith('---')) {
+		return markdown;
+	}
 
-        const withoutFrontMatter = markdown.replace(FRONT_MATTER_REGEX, '');
+	const withoutFrontMatter = markdown.replace(FRONT_MATTER_REGEX, '');
 
-        return withoutFrontMatter.replace(/^\s+/, '');
+	return withoutFrontMatter.replace(/^\s+/, '');
 }
 
 export function renderMarkdown(markdown?: string | null): string {
-        if (!markdown) {
-                return '';
-        }
+	if (!markdown) {
+		return '';
+	}
 
-        const cleanedMarkdown = stripFrontMatter(markdown);
+	const cleanedMarkdown = stripFrontMatter(markdown);
 
-        return marked.parse(cleanedMarkdown);
+	return marked.parse(cleanedMarkdown);
 }

--- a/src/support/markdown.ts
+++ b/src/support/markdown.ts
@@ -1,0 +1,30 @@
+import { marked } from 'marked';
+
+const FRONT_MATTER_REGEX = /^(?:\uFEFF)?---\s*[\r\n]+([\s\S]*?)\r?\n---\s*[\r\n]*/m;
+
+marked.use({
+        options: {
+                breaks: true,
+                gfm: true,
+        },
+});
+
+function stripFrontMatter(markdown: string): string {
+        if (!markdown.trimStart().startsWith('---')) {
+                return markdown;
+        }
+
+        const withoutFrontMatter = markdown.replace(FRONT_MATTER_REGEX, '');
+
+        return withoutFrontMatter.replace(/^\s+/, '');
+}
+
+export function renderMarkdown(markdown?: string | null): string {
+        if (!markdown) {
+                return '';
+        }
+
+        const cleanedMarkdown = stripFrontMatter(markdown);
+
+        return marked.parse(cleanedMarkdown);
+}

--- a/src/support/markdown.ts
+++ b/src/support/markdown.ts
@@ -2,11 +2,9 @@ import { marked } from 'marked';
 
 const FRONT_MATTER_REGEX = /^(?:\uFEFF)?---\s*[\r\n]+([\s\S]*?)\r?\n---\s*[\r\n]*/m;
 
-marked.use({
-        options: {
-                breaks: true,
-                gfm: true,
-        },
+marked.setOptions({
+        breaks: true,
+        gfm: true,
 });
 
 function stripFrontMatter(markdown: string): string {

--- a/tests/pages/PostPage.test.ts
+++ b/tests/pages/PostPage.test.ts
@@ -33,7 +33,9 @@ const getPost = vi.fn<[], Promise<PostResponse>>(() => Promise.resolve(post));
 
 vi.mock('@api/store.ts', () => ({ useApiStore: () => ({ getPost }) }));
 vi.mock('vue-router', () => ({ useRoute: () => ({ params: { slug: post.slug } }) }));
-vi.mock('marked', () => ({ marked: { use: vi.fn(), parse: vi.fn(() => '<p></p>') } }));
+const renderMarkdown = vi.hoisted(() => vi.fn(() => '<p></p>'));
+
+vi.mock('@/support/markdown.ts', () => ({ renderMarkdown }));
 vi.mock('dompurify', () => ({ default: { sanitize: vi.fn((html: string) => html) } }));
 vi.mock('highlight.js/lib/core', () => ({
 	default: {
@@ -70,9 +72,8 @@ describe('PostPage', () => {
 	});
 
 	it('processes markdown content', async () => {
-		const { marked } = await import('marked');
-		const DOMPurify = await import('dompurify');
-		const wrapper = mount(PostPage, {
+                const DOMPurify = await import('dompurify');
+                const wrapper = mount(PostPage, {
 			global: {
 				stubs: {
 					SideNavPartial: true,
@@ -85,10 +86,10 @@ describe('PostPage', () => {
 			},
 		});
 		await flushPromises();
-		expect(marked.parse).toHaveBeenCalledWith(post.content);
-		expect(DOMPurify.default.sanitize).toHaveBeenCalled();
-		expect(wrapper.html()).toContain('<p></p>');
-	});
+                expect(renderMarkdown).toHaveBeenCalledWith(post.content);
+                expect(DOMPurify.default.sanitize).toHaveBeenCalled();
+                expect(wrapper.html()).toContain('<p></p>');
+        });
 
 	it('handles post errors gracefully', async () => {
 		const error = new Error('fail');

--- a/tests/pages/PostPage.test.ts
+++ b/tests/pages/PostPage.test.ts
@@ -72,8 +72,8 @@ describe('PostPage', () => {
 	});
 
 	it('processes markdown content', async () => {
-                const DOMPurify = await import('dompurify');
-                const wrapper = mount(PostPage, {
+		const DOMPurify = await import('dompurify');
+		const wrapper = mount(PostPage, {
 			global: {
 				stubs: {
 					SideNavPartial: true,
@@ -86,10 +86,10 @@ describe('PostPage', () => {
 			},
 		});
 		await flushPromises();
-                expect(renderMarkdown).toHaveBeenCalledWith(post.content);
-                expect(DOMPurify.default.sanitize).toHaveBeenCalled();
-                expect(wrapper.html()).toContain('<p></p>');
-        });
+		expect(renderMarkdown).toHaveBeenCalledWith(post.content);
+		expect(DOMPurify.default.sanitize).toHaveBeenCalled();
+		expect(wrapper.html()).toContain('<p></p>');
+	});
 
 	it('handles post errors gracefully', async () => {
 		const error = new Error('fail');

--- a/tests/partials/EducationPartial.test.ts
+++ b/tests/partials/EducationPartial.test.ts
@@ -9,8 +9,8 @@ const renderMarkdown = vi.hoisted(() => vi.fn(() => '<p><strong>hi</strong></p>'
 vi.mock('@/support/markdown.ts', () => ({ renderMarkdown }));
 
 const education: EducationResponse[] = [
-        {
-                uuid: faker.string.uuid(),
+	{
+		uuid: faker.string.uuid(),
 		degree: faker.word.words(1),
 		school: faker.company.name(),
 		graduated_at: '2020',
@@ -22,9 +22,9 @@ const education: EducationResponse[] = [
 ];
 
 describe('EducationPartial', () => {
-        it('renders markdown as html', () => {
-                const wrapper = mount(EducationPartial, { props: { education } });
-                expect(renderMarkdown).toHaveBeenCalledWith('**hi**');
-                expect(wrapper.html()).toContain('<strong>hi</strong>');
-        });
+	it('renders markdown as html', () => {
+		const wrapper = mount(EducationPartial, { props: { education } });
+		expect(renderMarkdown).toHaveBeenCalledWith('**hi**');
+		expect(wrapper.html()).toContain('<strong>hi</strong>');
+	});
 });

--- a/tests/partials/EducationPartial.test.ts
+++ b/tests/partials/EducationPartial.test.ts
@@ -1,12 +1,16 @@
 import { mount } from '@vue/test-utils';
 import { faker } from '@faker-js/faker';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import EducationPartial from '@partials/EducationPartial.vue';
 import type { EducationResponse } from '@api/response/index.ts';
 
+const renderMarkdown = vi.hoisted(() => vi.fn(() => '<p><strong>hi</strong></p>'));
+
+vi.mock('@/support/markdown.ts', () => ({ renderMarkdown }));
+
 const education: EducationResponse[] = [
-	{
-		uuid: faker.string.uuid(),
+        {
+                uuid: faker.string.uuid(),
 		degree: faker.word.words(1),
 		school: faker.company.name(),
 		graduated_at: '2020',
@@ -18,8 +22,9 @@ const education: EducationResponse[] = [
 ];
 
 describe('EducationPartial', () => {
-	it('renders markdown as html', () => {
-		const wrapper = mount(EducationPartial, { props: { education } });
-		expect(wrapper.html()).toContain('<strong>hi</strong>');
-	});
+        it('renders markdown as html', () => {
+                const wrapper = mount(EducationPartial, { props: { education } });
+                expect(renderMarkdown).toHaveBeenCalledWith('**hi**');
+                expect(wrapper.html()).toContain('<strong>hi</strong>');
+        });
 });

--- a/tests/partials/RecommendationPartial.test.ts
+++ b/tests/partials/RecommendationPartial.test.ts
@@ -4,9 +4,12 @@ import { describe, it, expect, vi } from 'vitest';
 import RecommendationPartial from '@partials/RecommendationPartial.vue';
 import type { RecommendationsResponse } from '@api/response/index.ts';
 
+const renderMarkdown = vi.hoisted(() => vi.fn(() => '<p><strong>great</strong></p>'));
+
+vi.mock('@/support/markdown.ts', () => ({ renderMarkdown }));
 vi.mock('@/public.ts', () => ({
-	image: (p: string) => `/img/${p}`,
-	date: () => ({ format: () => 'now' }),
+        image: (p: string) => `/img/${p}`,
+        date: () => ({ format: () => 'now' }),
 }));
 
 describe('RecommendationPartial', () => {
@@ -25,9 +28,10 @@ describe('RecommendationPartial', () => {
 		},
 	];
 
-	it('sanitises and formats recommendation', () => {
-		const wrapper = mount(RecommendationPartial, { props: { recommendations: data } });
-		expect(wrapper.html()).toContain('<strong>great</strong>');
-		expect(wrapper.text()).toContain('now');
-	});
+        it('sanitises and formats recommendation', () => {
+                const wrapper = mount(RecommendationPartial, { props: { recommendations: data } });
+                expect(renderMarkdown).toHaveBeenCalledWith('**great**');
+                expect(wrapper.html()).toContain('<strong>great</strong>');
+                expect(wrapper.text()).toContain('now');
+        });
 });

--- a/tests/partials/RecommendationPartial.test.ts
+++ b/tests/partials/RecommendationPartial.test.ts
@@ -8,8 +8,8 @@ const renderMarkdown = vi.hoisted(() => vi.fn(() => '<p><strong>great</strong></
 
 vi.mock('@/support/markdown.ts', () => ({ renderMarkdown }));
 vi.mock('@/public.ts', () => ({
-        image: (p: string) => `/img/${p}`,
-        date: () => ({ format: () => 'now' }),
+	image: (p: string) => `/img/${p}`,
+	date: () => ({ format: () => 'now' }),
 }));
 
 describe('RecommendationPartial', () => {
@@ -28,10 +28,10 @@ describe('RecommendationPartial', () => {
 		},
 	];
 
-        it('sanitises and formats recommendation', () => {
-                const wrapper = mount(RecommendationPartial, { props: { recommendations: data } });
-                expect(renderMarkdown).toHaveBeenCalledWith('**great**');
-                expect(wrapper.html()).toContain('<strong>great</strong>');
-                expect(wrapper.text()).toContain('now');
-        });
+	it('sanitises and formats recommendation', () => {
+		const wrapper = mount(RecommendationPartial, { props: { recommendations: data } });
+		expect(renderMarkdown).toHaveBeenCalledWith('**great**');
+		expect(wrapper.html()).toContain('<strong>great</strong>');
+		expect(wrapper.text()).toContain('now');
+	});
 });

--- a/tests/support/markdown.test.ts
+++ b/tests/support/markdown.test.ts
@@ -4,23 +4,23 @@ import { renderMarkdown } from '@/support/markdown.ts';
 const SAMPLE_WITH_FRONT_MATTER = `---\ntitle: Example Title\nexcerpt: Example excerpt\nslug: example-slug\n---\n\n![hero](https://example.com/hero.jpg)\n\n## Heading\n\n- Item one\n- Item two\n\n| Col A | Col B |\n| ----- | ----- |\n| A     | B     |\n`;
 
 describe('renderMarkdown', () => {
-        it('returns an empty string when markdown is missing', () => {
-                expect(renderMarkdown(undefined)).toBe('');
-                expect(renderMarkdown(null)).toBe('');
-        });
+	it('returns an empty string when markdown is missing', () => {
+		expect(renderMarkdown(undefined)).toBe('');
+		expect(renderMarkdown(null)).toBe('');
+	});
 
-        it('strips YAML front matter before rendering markdown', () => {
-                const html = renderMarkdown(SAMPLE_WITH_FRONT_MATTER);
+	it('strips YAML front matter before rendering markdown', () => {
+		const html = renderMarkdown(SAMPLE_WITH_FRONT_MATTER);
 
-                expect(html).not.toContain('Example Title');
-                expect(html).toContain('<h2>Heading</h2>');
-                expect(html).toContain('<ul>');
-                expect(html).toContain('<table>');
-        });
+		expect(html).not.toContain('Example Title');
+		expect(html).toContain('<h2>Heading</h2>');
+		expect(html).toContain('<ul>');
+		expect(html).toContain('<table>');
+	});
 
-        it('renders markdown without front matter unchanged', () => {
-                const html = renderMarkdown('## Just Heading');
+	it('renders markdown without front matter unchanged', () => {
+		const html = renderMarkdown('## Just Heading');
 
-                expect(html).toContain('<h2>Just Heading</h2>');
-        });
+		expect(html).toContain('<h2>Just Heading</h2>');
+	});
 });

--- a/tests/support/markdown.test.ts
+++ b/tests/support/markdown.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { renderMarkdown } from '@/support/markdown.ts';
+
+const SAMPLE_WITH_FRONT_MATTER = `---\ntitle: Example Title\nexcerpt: Example excerpt\nslug: example-slug\n---\n\n![hero](https://example.com/hero.jpg)\n\n## Heading\n\n- Item one\n- Item two\n\n| Col A | Col B |\n| ----- | ----- |\n| A     | B     |\n`;
+
+describe('renderMarkdown', () => {
+        it('returns an empty string when markdown is missing', () => {
+                expect(renderMarkdown(undefined)).toBe('');
+                expect(renderMarkdown(null)).toBe('');
+        });
+
+        it('strips YAML front matter before rendering markdown', () => {
+                const html = renderMarkdown(SAMPLE_WITH_FRONT_MATTER);
+
+                expect(html).not.toContain('Example Title');
+                expect(html).toContain('<h2>Heading</h2>');
+                expect(html).toContain('<ul>');
+                expect(html).toContain('<table>');
+        });
+
+        it('renders markdown without front matter unchanged', () => {
+                const html = renderMarkdown('## Just Heading');
+
+                expect(html).toContain('<h2>Just Heading</h2>');
+        });
+});


### PR DESCRIPTION
## Summary
- strip YAML front matter from markdown before rendering so posts no longer display metadata headers
- keep the shared renderer configuration while normalising content prior to parsing
- add unit coverage for the markdown helper to guard front-matter removal and basic rendering

## Testing
- `npm test` *(fails: vitest binary is unavailable because dependencies cannot be installed in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ca27a856b48333be727fe9e9949d0f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Unified Markdown rendering across posts, education, and recommendations.
  - Improved support for GitHub Flavored Markdown (tables, lists, line breaks).
  - Automatically strips YAML front matter for cleaner displayed content.
  - Continued safe HTML sanitization for rendered content.

- Refactor
  - Components now use a centralized Markdown renderer for consistent output.

- Tests
  - Added unit and component tests for Markdown rendering, front-matter handling, and HTML output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->