### PR TITLE
Adjust deploy workflow for test-formatting label

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,15 +1,17 @@
 name: VPS
 
 on:
-    push:
-        branches: [main]
+  pull_request_target:
+    types:
+      - labeled
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   build-and-push:
+    if: github.event.label.name == 'test-formatting'
     strategy:
       matrix:
         os: [ubuntu-24.04]
@@ -25,10 +27,18 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set Image Tag
         id: set-tag
-        run: echo "IMAGE_TAG=${GITHUB_SHA::7}" >> $GITHUB_OUTPUT
+        env:
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          IMAGE_TAG=${PR_SHA:0:7}
+          echo "IMAGE_TAG=$IMAGE_TAG" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker with Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary
- trigger the deploy workflow only when a pull request is labeled with `test-formatting`
- ensure the workflow checks out and tags the pull request head commit while respecting per-PR concurrency

## Testing
- not run (workflow definition change)


------
https://chatgpt.com/codex/tasks/task_e_68ca651815888333937c8b69eadd833e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Deployment workflow now runs on labeled pull requests for safer PR-based builds.
  * Builds are gated by a “test-formatting” label to control image creation.
  * Concurrency is isolated per PR to prevent overlapping runs.
  * Docker images are tagged with the short PR commit SHA for clearer traceability.
  * Checkout uses the PR head for accurate sources.
  * Optional .env creation from secrets enables preview environments.
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->