### PR TITLE
Adjust post markdown visuals

### DIFF
--- a/src/css/support/blog.css
+++ b/src/css/support/blog.css
@@ -182,7 +182,7 @@
 
 .post-markdown pre {
     @apply bg-slate-900 text-slate-100 dark:bg-slate-900/90 dark:text-slate-100 rounded-2xl p-6 overflow-x-auto text-sm;
-    scrollbar-width: thin;
+    scrollbar-width: thin; /* Firefox */
     scrollbar-color: theme(colors.fuchsia.500) theme(colors.gray.100);
 }
 
@@ -229,7 +229,6 @@
 }
 
 .post-markdown img {
-    @apply shadow-sm dark:shadow-none;
+    @apply shadow-sm dark:shadow-none rounded-md;
     max-width: 100%;
-    border-radius: 5px;
 }


### PR DESCRIPTION
## Summary
- set post markdown images to use a consistent 5px corner radius
- fix blockquote spacing so top and bottom padding stays even
- add themed scrollbar styling to code blocks rendered in posts

## Testing
- npm run build *(fails: local Vite binary unavailable in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ca76e0923c8333b5c76d3a786f4638

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved blockquote readability with increased padding and trimmed first/last-child margins.
  * Enhanced code block usability with thin, themed scrollbars, including hover states and full light/dark mode support for better contrast.
  * Refined image presentation: responsive max-width, subtler rounded corners, and preserved shadows (dark mode unchanged) for a cleaner, consistent look across posts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->