### PR TITLE
Refine post markdown scrollbars

### DIFF
--- a/src/css/support/blog.css
+++ b/src/css/support/blog.css
@@ -183,7 +183,7 @@
 .post-markdown pre {
     @apply bg-slate-900 text-slate-100 dark:bg-slate-900/90 dark:text-slate-100 rounded-2xl p-6 overflow-x-auto text-sm;
     scrollbar-width: thin; /* Firefox */
-    scrollbar-color: var(--post-scrollbar-thumb) var(--post-scrollbar-track);
+    scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
 }
 
 .post-markdown code {

--- a/src/css/support/blog.css
+++ b/src/css/support/blog.css
@@ -183,41 +183,7 @@
 .post-markdown pre {
     @apply bg-slate-900 text-slate-100 dark:bg-slate-900/90 dark:text-slate-100 rounded-2xl p-6 overflow-x-auto text-sm;
     scrollbar-width: thin; /* Firefox */
-    scrollbar-color: theme(colors.fuchsia.500) theme(colors.gray.100);
-}
-
-.post-markdown pre::-webkit-scrollbar {
-    width: 8px;
-}
-
-.post-markdown pre::-webkit-scrollbar-track {
-    background-color: theme(colors.gray.100);
-    border-radius: 10px;
-}
-
-.post-markdown pre::-webkit-scrollbar-thumb {
-    background-color: theme(colors.fuchsia.500);
-    border-radius: 10px;
-}
-
-.post-markdown pre::-webkit-scrollbar-thumb:hover {
-    background-color: theme(colors.fuchsia.400);
-}
-
-.dark .post-markdown pre {
-    scrollbar-color: theme(colors.teal.500) theme(colors.slate.800);
-}
-
-.dark .post-markdown pre::-webkit-scrollbar-track {
-    background-color: theme(colors.slate.800);
-}
-
-.dark .post-markdown pre::-webkit-scrollbar-thumb {
-    background-color: theme(colors.teal.500);
-}
-
-.dark .post-markdown pre::-webkit-scrollbar-thumb:hover {
-    background-color: theme(colors.teal.400);
+    scrollbar-color: var(--post-scrollbar-thumb) var(--post-scrollbar-track);
 }
 
 .post-markdown code {

--- a/src/css/support/blog.css
+++ b/src/css/support/blog.css
@@ -181,6 +181,9 @@
 }
 
 .post-markdown pre {
+    --scrollbar-track: var(--custom-scrollbar-track);
+    --scrollbar-thumb: var(--custom-scrollbar-thumb);
+    --scrollbar-thumb-hover: var(--custom-scrollbar-thumb-hover);
     @apply bg-slate-900 text-slate-100 dark:bg-slate-900/90 dark:text-slate-100 rounded-2xl p-6 overflow-x-auto text-sm;
     scrollbar-width: thin; /* Firefox */
     scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);

--- a/src/css/support/theme.css
+++ b/src/css/support/theme.css
@@ -48,23 +48,23 @@
 		width 0.1s ease-out;
 }
 
+
 :root {
-    --custom-scrollbar-track: theme(colors.gray.100);
-    --custom-scrollbar-thumb: theme(colors.fuchsia.500);
-    --custom-scrollbar-thumb-hover: theme(colors.fuchsia.400);
+        --custom-scrollbar-track: var(--color-gray-100);
+        --custom-scrollbar-thumb: var(--color-fuchsia-500);
+        --custom-scrollbar-thumb-hover: var(--color-fuchsia-400);
 }
 
 .dark {
-    --custom-scrollbar-track: theme(colors.slate.800);
-    --custom-scrollbar-thumb: theme(colors.teal.500);
-    --custom-scrollbar-thumb-hover: theme(colors.teal.400);
+        --custom-scrollbar-track: var(--color-slate-800);
+        --custom-scrollbar-thumb: var(--color-teal-500);
+        --custom-scrollbar-thumb-hover: var(--color-teal-400);
 }
 
-.custom-scrollbar,
-.post-markdown pre {
-    --scrollbar-track: var(--custom-scrollbar-track);
-    --scrollbar-thumb: var(--custom-scrollbar-thumb);
-    --scrollbar-thumb-hover: var(--custom-scrollbar-thumb-hover);
+.custom-scrollbar {
+        --scrollbar-track: var(--custom-scrollbar-track);
+        --scrollbar-thumb: var(--custom-scrollbar-thumb);
+        --scrollbar-thumb-hover: var(--custom-scrollbar-thumb-hover);
 }
 
 .custom-scrollbar,

--- a/src/css/support/theme.css
+++ b/src/css/support/theme.css
@@ -48,41 +48,60 @@
 		width 0.1s ease-out;
 }
 
-/* --- Default (Light Theme) Styles --- */
-.custom-scrollbar::-webkit-scrollbar {
-    width: 8px;
+:root {
+    --custom-scrollbar-track: #f3f4f6; /* Tailwind gray-100 */
+    --custom-scrollbar-thumb: #d946ef; /* Tailwind fuchsia-500 */
+    --custom-scrollbar-thumb-hover: #e879f9; /* Tailwind fuchsia-400 */
+    --post-scrollbar-track: #f3f4f6; /* Tailwind gray-100 */
+    --post-scrollbar-thumb: #d946ef; /* Tailwind fuchsia-500 */
+    --post-scrollbar-thumb-hover: #e879f9; /* Tailwind fuchsia-400 */
 }
 
-.custom-scrollbar::-webkit-scrollbar-track {
-    background-color: theme(colors.gray.100);
-    border-radius: 10px;
-}
-
-.custom-scrollbar::-webkit-scrollbar-thumb {
-    background-color: theme(colors.fuchsia.500); /* Changed for light theme */
-    border-radius: 10px;
-}
-
-.custom-scrollbar::-webkit-scrollbar-thumb:hover {
-    background-color: theme(colors.fuchsia.400); /* Changed for light theme */
+.dark {
+    --custom-scrollbar-track: #1e293b; /* Tailwind slate-800 */
+    --custom-scrollbar-thumb: #14b8a6; /* Tailwind teal-500 */
+    --custom-scrollbar-thumb-hover: #2dd4bf; /* Tailwind teal-400 */
+    --post-scrollbar-track: #1e293b; /* Tailwind slate-800 */
+    --post-scrollbar-thumb: #14b8a6; /* Tailwind teal-500 */
+    --post-scrollbar-thumb-hover: #2dd4bf; /* Tailwind teal-400 */
 }
 
 .custom-scrollbar {
-    scrollbar-width: thin;
-    scrollbar-color: theme(colors.fuchsia.500) theme(colors.gray.100); /* Changed for light theme */
+    --scrollbar-track: var(--custom-scrollbar-track);
+    --scrollbar-thumb: var(--custom-scrollbar-thumb);
+    --scrollbar-thumb-hover: var(--custom-scrollbar-thumb-hover);
+}
+
+.post-markdown pre {
+    --scrollbar-track: var(--post-scrollbar-track);
+    --scrollbar-thumb: var(--post-scrollbar-thumb);
+    --scrollbar-thumb-hover: var(--post-scrollbar-thumb-hover);
 }
 
 
-/* --- Dark Theme Overrides --- */
-
-.dark .custom-scrollbar::-webkit-scrollbar-thumb {
-    background-color: theme(colors.teal.500); /* Changed for dark theme */
+.custom-scrollbar {
+    scrollbar-width: thin; /* Firefox */
+    scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
 }
 
-.dark .custom-scrollbar::-webkit-scrollbar-thumb:hover {
-    background-color: theme(colors.teal.400); /* Changed for dark theme */
+.custom-scrollbar::-webkit-scrollbar,
+.post-markdown pre::-webkit-scrollbar {
+    width: 8px;
 }
 
-.dark .custom-scrollbar {
-    scrollbar-color: theme(colors.teal.500) theme(colors.slate.800); /* Changed for dark theme */
+.custom-scrollbar::-webkit-scrollbar-track,
+.post-markdown pre::-webkit-scrollbar-track {
+    background-color: var(--scrollbar-track);
+    border-radius: 10px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb,
+.post-markdown pre::-webkit-scrollbar-thumb {
+    background-color: var(--scrollbar-thumb);
+    border-radius: 10px;
+}
+
+.custom-scrollbar::-webkit-scrollbar-thumb:hover,
+.post-markdown pre::-webkit-scrollbar-thumb:hover {
+    background-color: var(--scrollbar-thumb-hover);
 }

--- a/src/css/support/theme.css
+++ b/src/css/support/theme.css
@@ -49,37 +49,26 @@
 }
 
 :root {
-    --custom-scrollbar-track: #f3f4f6; /* Tailwind gray-100 */
-    --custom-scrollbar-thumb: #d946ef; /* Tailwind fuchsia-500 */
-    --custom-scrollbar-thumb-hover: #e879f9; /* Tailwind fuchsia-400 */
-    --post-scrollbar-track: #f3f4f6; /* Tailwind gray-100 */
-    --post-scrollbar-thumb: #d946ef; /* Tailwind fuchsia-500 */
-    --post-scrollbar-thumb-hover: #e879f9; /* Tailwind fuchsia-400 */
+    --custom-scrollbar-track: theme(colors.gray.100);
+    --custom-scrollbar-thumb: theme(colors.fuchsia.500);
+    --custom-scrollbar-thumb-hover: theme(colors.fuchsia.400);
 }
 
 .dark {
-    --custom-scrollbar-track: #1e293b; /* Tailwind slate-800 */
-    --custom-scrollbar-thumb: #14b8a6; /* Tailwind teal-500 */
-    --custom-scrollbar-thumb-hover: #2dd4bf; /* Tailwind teal-400 */
-    --post-scrollbar-track: #1e293b; /* Tailwind slate-800 */
-    --post-scrollbar-thumb: #14b8a6; /* Tailwind teal-500 */
-    --post-scrollbar-thumb-hover: #2dd4bf; /* Tailwind teal-400 */
+    --custom-scrollbar-track: theme(colors.slate.800);
+    --custom-scrollbar-thumb: theme(colors.teal.500);
+    --custom-scrollbar-thumb-hover: theme(colors.teal.400);
 }
 
-.custom-scrollbar {
+.custom-scrollbar,
+.post-markdown pre {
     --scrollbar-track: var(--custom-scrollbar-track);
     --scrollbar-thumb: var(--custom-scrollbar-thumb);
     --scrollbar-thumb-hover: var(--custom-scrollbar-thumb-hover);
 }
 
+.custom-scrollbar,
 .post-markdown pre {
-    --scrollbar-track: var(--post-scrollbar-track);
-    --scrollbar-thumb: var(--post-scrollbar-thumb);
-    --scrollbar-thumb-hover: var(--post-scrollbar-thumb-hover);
-}
-
-
-.custom-scrollbar {
     scrollbar-width: thin; /* Firefox */
     scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
 }


### PR DESCRIPTION
## Summary
- define scrollbar colour CSS variables for light and dark themes and reference them from the shared custom scrollbar styles
- reuse the custom scrollbar styling for `.post-markdown pre` elements via CSS variables to remove the duplicated WebKit rules
- update the blog stylesheet to rely on the new variables for Firefox scrollbar colours

## Testing
- npm run build *(fails: Vite not found; npm install hung for several minutes in the container)*

## Summary by CodeRabbit

- New Features
  - Consistent, themed scrollbar styling across app areas and blog posts, including hover states and thin width.
- Style
  - Unified light/dark mode scrollbar colours for a cohesive look.
  - Improved visual polish with rounded tracks and thumbs.
- Bug Fixes
  - Better cross-browser compatibility, including Firefox support for themed scrollbars.
- Refactor
  - Centralised scrollbar theming using design tokens to ensure consistent application-wide behaviour.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Scrollbar theming now driven by centralized CSS tokens for consistent appearance across app areas and blog posts.

- Style
  - Unified light/dark scrollbar colors, rounded tracks/thumbs, hover states, and thin sizing for improved polish.

- Bug Fixes
  - Improved cross-browser support (including Firefox) for themed scrollbars.

- Refactor
  - Replaced per-theme declarations with token-based mappings to simplify and standardize scrollbar styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->