### PR TITLE
Revert "better caddy"

### DIFF
--- a/caddy/WebCaddyfile.internal
+++ b/caddy/WebCaddyfile.internal
@@ -49,17 +49,8 @@
         respond 404
     }
 
-    @missing_static_ext {
-        path_regexp staticext \.(?:css|js|mjs|map|png|jpe?g|webp|avif|svg|gif|ico|woff2?|ttf|otf|json|txt|pdf|xml|webm|mp4|wasm|webmanifest)$
-        not file
-    }
-
     # Static SPA
     # Bot/social previews → serve static share pages under /seo/*.seo.html
-    header @missing_static_ext Cache-Control "no-store"
-    header @missing_static_ext Content-Type "text/plain; charset=utf-8"
-    respond @missing_static_ext 404
-
     @sharebots header_regexp ua User-Agent "(?i)(googlebot|bingbot|duckduckbot|yandex(bot|images)|baiduspider|facebookexternalhit|twitterbot|linkedinbot|slackbot|telegrambot|discordbot|pinterest|whatsapp|skypeuripreview|bitlybot|vkshare|quora link preview|embedly|outbrain|nuzzel|ios link preview|snapchat|applebot)"
     handle @sharebots {
         root * /usr/share/caddy


### PR DESCRIPTION
Reverts oullin/web#71

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Eliminated unnecessary 404 responses for URLs that resemble static files but don’t exist, allowing the SPA fallback to load correctly.
  * Ensures client-side routes with file-like paths resolve to the app shell instead of failing.

* **Chores**
  * Simplified server configuration by removing special-case handling for missing static extensions; standard headers now apply to these requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->