### PR TITLE
Add loading placeholder for article cover images

### DIFF
--- a/src/partials/ArticleItemPartial.vue
+++ b/src/partials/ArticleItemPartial.vue
@@ -1,45 +1,76 @@
 <template>
-	<article v-if="item" class="py-5 border-b border-slate-100 dark:border-slate-800">
-		<div class="flex items-start">
-			<img class="rounded-sm w-16 h-16 sm:w-[88px] sm:h-[88px] object-cover mr-6" :src="item.cover_image_url" width="88" height="88" :alt="item.title" decoding="async" fetchpriority="high" />
-			<div>
-				<div class="text-xs text-slate-700 uppercase mb-1 dark:text-slate-500">
-					{{ date().format(new Date(item.published_at)) }}
-				</div>
-				<h3 class="text-slate-700 font-aspekta text-lg font-[650] mb-1 dark:text-slate-300">
-					<router-link
-						v-lazy-link
-						class="inline-flex relative hover:text-fuchsia-500 dark:hover:text-teal-500 duration-150 ease-out before:scale-x-0 before:origin-center before:absolute before:inset-0 before:bg-sky-200 dark:before:bg-sky-500 before:opacity-30 before:-z-10 before:translate-y-1/4 before:-rotate-2 hover:before:scale-100 before:duration-150 before:ease-in-out"
-						:to="{ name: 'PostDetail', params: { slug: item.slug } }"
-					>
-						{{ item.title }}
-					</router-link>
-				</h3>
-				<div class="flex">
-					<div class="grow text-sm text-slate-500 dark:text-slate-600">
-						{{ item.excerpt }}
-					</div>
-					<router-link
-						v-lazy-link
-						class="hidden lg:flex shrink-0 text-fuchsia-500 dark:text-teal-500 items-center justify-center w-12 group"
-						:to="{ name: 'PostDetail', params: { slug: item.slug } }"
-						tabindex="-1"
-					>
-						<svg class="fill-current group-hover:translate-x-2 duration-150 ease-in-out" xmlns="http://www.w3.org/2000/svg" width="14" height="12">
-							<path d="M9.586 5 6.293 1.707 7.707.293 13.414 6l-5.707 5.707-1.414-1.414L9.586 7H0V5h9.586Z" />
-						</svg>
-					</router-link>
-				</div>
-			</div>
-		</div>
-	</article>
+        <article v-if="item" class="py-5 border-b border-slate-100 dark:border-slate-800">
+                <div class="flex items-start">
+                        <div class="relative flex-shrink-0 mr-6 w-16 h-16 sm:w-[88px] sm:h-[88px]">
+                                <div
+                                        v-if="!isImageLoaded"
+                                        class="w-full h-full rounded-sm bg-slate-200 dark:bg-slate-800 animate-pulse"
+                                ></div>
+                                <img
+                                        :src="item.cover_image_url"
+                                        :alt="item.title"
+                                        width="88"
+                                        height="88"
+                                        class="rounded-sm w-full h-full object-cover transition-opacity duration-300"
+                                        :class="isImageLoaded ? 'opacity-100' : 'opacity-0'"
+                                        decoding="async"
+                                        loading="lazy"
+                                        @load="onImageLoaded"
+                                        @error="onImageLoaded"
+                                />
+                        </div>
+                        <div>
+                                <div class="text-xs text-slate-700 uppercase mb-1 dark:text-slate-500">
+                                        {{ date().format(new Date(item.published_at)) }}
+                                </div>
+                                <h3 class="text-slate-700 font-aspekta text-lg font-[650] mb-1 dark:text-slate-300">
+                                        <router-link
+                                                v-lazy-link
+                                                class="inline-flex relative hover:text-fuchsia-500 dark:hover:text-teal-500 duration-150 ease-out before:scale-x-0 before:origin-center before:absolute before:inset-0 before:bg-sky-200 dark:before:bg-sky-500 before:opacity-30 before:-z-10 before:translate-y-1/4 before:-rotate-2 hover:before:scale-100 before:duration-150 before:ease-in-out"
+                                                :to="{ name: 'PostDetail', params: { slug: item.slug } }"
+                                        >
+                                                {{ item.title }}
+                                        </router-link>
+                                </h3>
+                                <div class="flex">
+                                        <div class="grow text-sm text-slate-500 dark:text-slate-600">
+                                                {{ item.excerpt }}
+                                        </div>
+                                        <router-link
+                                                v-lazy-link
+                                                class="hidden lg:flex shrink-0 text-fuchsia-500 dark:text-teal-500 items-center justify-center w-12 group"
+                                                :to="{ name: 'PostDetail', params: { slug: item.slug } }"
+                                                tabindex="-1"
+                                        >
+                                                <svg class="fill-current group-hover:translate-x-2 duration-150 ease-in-out" xmlns="http://www.w3.org/2000/svg" width="14" height="12">
+                                                        <path d="M9.586 5 6.293 1.707 7.707.293 13.414 6l-5.707 5.707-1.414-1.414L9.586 7H0V5h9.586Z" />
+                                                </svg>
+                                        </router-link>
+                                </div>
+                        </div>
+                </div>
+        </article>
 </template>
 
 <script setup lang="ts">
+import { ref, watch } from 'vue';
 import { date } from '@/public.ts';
 import type { PostResponse } from '@api/response/index.ts';
 
-defineProps<{
-	item: PostResponse;
+const props = defineProps<{
+        item: PostResponse;
 }>();
+
+const isImageLoaded = ref(false);
+
+const onImageLoaded = () => {
+        isImageLoaded.value = true;
+};
+
+watch(
+        () => props.item.cover_image_url,
+        () => {
+                isImageLoaded.value = false;
+        },
+);
 </script>


### PR DESCRIPTION
## Summary
- add a skeleton placeholder so article thumbnails maintain layout while loading
- lazily load article cover images and reset the placeholder when the source changes

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68d65a9494dc83339cdf40c4796325f8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Article images now lazy-load to improve perceived performance.
  - Skeleton placeholder displays while images load; images fade in smoothly when ready.
  - Responsive placeholder behavior and graceful handling of image load errors.

- Refactor
  - Updated article item markup to support new image loading experience while preserving layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->