### PR TITLE
Add resume section navigation menu

### DIFF
--- a/src/pages/ResumePage.vue
+++ b/src/pages/ResumePage.vue
@@ -13,11 +13,38 @@
 						<!-- Middle area -->
 						<div class="grow">
 							<div class="max-w-[700px]">
-								<section>
-									<!-- Page title -->
-									<h1 class="h1 font-aspekta mb-12">My resume</h1>
-									<!-- Page content -->
-									<div class="text-slate-500 dark:text-slate-400 space-y-12">
+                                                                <section>
+                                                                        <!-- Page title -->
+                                                                        <h1 class="h1 font-aspekta mb-6">My resume</h1>
+
+                                                                        <nav
+                                                                                aria-label="Resume sections"
+                                                                                class="flex flex-wrap items-center gap-3 text-sm font-medium text-slate-500 dark:text-slate-400 mb-12"
+                                                                        >
+                                                                                <a
+                                                                                        class="inline-flex items-center gap-2 rounded-full border border-slate-200/70 dark:border-slate-700/80 px-4 py-2 transition-colors hover:border-fuchsia-400/70 hover:text-slate-800 dark:hover:text-slate-100"
+                                                                                        href="#education"
+                                                                                >
+                                                                                        <span class="size-2 rounded-full bg-fuchsia-400/70"></span>
+                                                                                        Education
+                                                                                </a>
+                                                                                <a
+                                                                                        class="inline-flex items-center gap-2 rounded-full border border-slate-200/70 dark:border-slate-700/80 px-4 py-2 transition-colors hover:border-fuchsia-400/70 hover:text-slate-800 dark:hover:text-slate-100"
+                                                                                        href="#experience"
+                                                                                >
+                                                                                        <span class="size-2 rounded-full bg-fuchsia-400/70"></span>
+                                                                                        Work Experience
+                                                                                </a>
+                                                                                <a
+                                                                                        class="inline-flex items-center gap-2 rounded-full border border-slate-200/70 dark:border-slate-700/80 px-4 py-2 transition-colors hover:border-fuchsia-400/70 hover:text-slate-800 dark:hover:text-slate-100"
+                                                                                        href="#recommendations"
+                                                                                >
+                                                                                        <span class="size-2 rounded-full bg-fuchsia-400/70"></span>
+                                                                                        Recommendations
+                                                                                </a>
+                                                                        </nav>
+                                                                        <!-- Page content -->
+                                                                        <div class="text-slate-500 dark:text-slate-400 space-y-12">
 										<EducationPartial v-if="education" :education="education" />
 										<ExperiencePartial v-if="experience" :experience="experience" />
 										<RecommendationPartial v-if="recommendations" :recommendations="recommendations" />

--- a/src/partials/EducationPartial.vue
+++ b/src/partials/EducationPartial.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="space-y-8">
+	<section id="education" class="space-y-8">
 		<h2 class="h3 font-aspekta text-slate-800 dark:text-slate-100">Education</h2>
 		<ul class="space-y-8">
 			<!-- Item -->
@@ -35,7 +35,7 @@
 				</div>
 			</li>
 		</ul>
-	</div>
+	</section>
 </template>
 
 <script setup lang="ts">

--- a/src/partials/ExperiencePartial.vue
+++ b/src/partials/ExperiencePartial.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="space-y-8">
+	<section id="experience" class="space-y-8">
 		<h2 class="h2 font-aspekta text-slate-700 dark:text-slate-300">Work Experience</h2>
 		<ul class="space-y-8">
 			<!-- Item -->
@@ -37,7 +37,7 @@
 				</div>
 			</li>
 		</ul>
-	</div>
+	</section>
 </template>
 <script setup lang="ts">
 import type { ExperienceResponse } from '@api/response/index.ts';

--- a/src/partials/RecommendationPartial.vue
+++ b/src/partials/RecommendationPartial.vue
@@ -1,5 +1,5 @@
 <template>
-	<div class="space-y-8">
+	<section id="recommendations" class="space-y-8">
 		<h2 class="h3 font-aspekta text-slate-800 dark:text-slate-100">Recommendations</h2>
 		<ul class="space-y-8">
 			<!-- Item -->
@@ -23,7 +23,7 @@
 				</div>
 			</li>
 		</ul>
-	</div>
+	</section>
 </template>
 
 <script setup lang="ts">


### PR DESCRIPTION
## Summary
- add a quick navigation menu at the top of the resume page for education, experience, and recommendations
- tag each resume section with an anchor so the navigation links scroll to the proper area

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_e_68db8ea373d08333a625ebbc83c5061d