### PR TITLE
Add tests for skeleton partial components

### DIFF
--- a/tests/partials/ArticleItemSkeletonPartial.test.ts
+++ b/tests/partials/ArticleItemSkeletonPartial.test.ts
@@ -1,0 +1,19 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import ArticleItemSkeletonPartial from '@partials/ArticleItemSkeletonPartial.vue';
+
+describe('ArticleItemSkeletonPartial', () => {
+	it('is animated by default', () => {
+		const wrapper = mount(ArticleItemSkeletonPartial);
+
+		expect(wrapper.classes()).toContain('animate-pulse');
+	});
+
+	it('can disable the animation', () => {
+		const wrapper = mount(ArticleItemSkeletonPartial, {
+			props: { isAnimated: false },
+		});
+
+		expect(wrapper.classes()).not.toContain('animate-pulse');
+	});
+});

--- a/tests/partials/ArticleItemSkeletonPartial.test.ts
+++ b/tests/partials/ArticleItemSkeletonPartial.test.ts
@@ -6,7 +6,7 @@ describe('ArticleItemSkeletonPartial', () => {
 	it('is animated by default', () => {
 		const wrapper = mount(ArticleItemSkeletonPartial);
 
-		expect(wrapper.classes()).toContain('animate-pulse');
+		expect(wrapper.attributes('class')).toContain('animate-pulse');
 	});
 
 	it('can disable the animation', () => {
@@ -14,6 +14,6 @@ describe('ArticleItemSkeletonPartial', () => {
 			props: { isAnimated: false },
 		});
 
-		expect(wrapper.classes()).not.toContain('animate-pulse');
+		expect(wrapper.attributes('class')).not.toContain('animate-pulse');
 	});
 });

--- a/tests/partials/ArticlesListPartial.test.ts
+++ b/tests/partials/ArticlesListPartial.test.ts
@@ -191,12 +191,12 @@ describe('ArticlesListPartial', () => {
 		// Coalesced or duplicated triggers are OK; we only require that a refresh was scheduled.
 		expect(getPosts.mock.calls.length).toBeGreaterThan(initialGetPostsCalls);
 
-		let skeletons = wrapper.findAllComponents(ArticleItemSkeletonPartial);
+		let skeletons = wrapper.findAll('[aria-busy="true"] article[aria-hidden="true"]');
 		let attempts = 0;
 
 		while (skeletons.length !== posts.length && attempts < 10) {
 			await nextTick();
-			skeletons = wrapper.findAllComponents(ArticleItemSkeletonPartial);
+			skeletons = wrapper.findAll('[aria-busy="true"] article[aria-hidden="true"]');
 			attempts += 1;
 		}
 

--- a/tests/partials/PostPageSkeletonPartial.test.ts
+++ b/tests/partials/PostPageSkeletonPartial.test.ts
@@ -1,0 +1,19 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import PostPageSkeletonPartial from '@partials/PostPageSkeletonPartial.vue';
+
+describe('PostPageSkeletonPartial', () => {
+	it('exposes a stable test id', () => {
+		const wrapper = mount(PostPageSkeletonPartial);
+
+		const root = wrapper.get('[data-testid="post-page-skeleton"]');
+		expect(root.exists()).toBe(true);
+	});
+
+	it('is identified as non-interactive placeholder', () => {
+		const wrapper = mount(PostPageSkeletonPartial);
+
+		expect(wrapper.attributes('aria-hidden')).toBe('true');
+		expect(wrapper.classes()).toContain('animate-pulse');
+	});
+});

--- a/tests/partials/PostPageSkeletonPartial.test.ts
+++ b/tests/partials/PostPageSkeletonPartial.test.ts
@@ -14,6 +14,6 @@ describe('PostPageSkeletonPartial', () => {
 		const wrapper = mount(PostPageSkeletonPartial);
 
 		expect(wrapper.attributes('aria-hidden')).toBe('true');
-		expect(wrapper.classes()).toContain('animate-pulse');
+		expect(wrapper.attributes('class')).toContain('animate-pulse');
 	});
 });

--- a/tests/partials/ProjectCardSkeletonPartial.test.ts
+++ b/tests/partials/ProjectCardSkeletonPartial.test.ts
@@ -6,7 +6,7 @@ describe('ProjectCardSkeletonPartial', () => {
 	it('renders animated wrapper by default', () => {
 		const wrapper = mount(ProjectCardSkeletonPartial);
 
-		expect(wrapper.classes()).toContain('animate-pulse');
+		expect(wrapper.attributes('class')).toContain('animate-pulse');
 	});
 
 	it('merges custom wrapper classes', () => {
@@ -22,6 +22,6 @@ describe('ProjectCardSkeletonPartial', () => {
 			props: { isAnimated: false },
 		});
 
-		expect(wrapper.classes()).not.toContain('animate-pulse');
+		expect(wrapper.attributes('class')).not.toContain('animate-pulse');
 	});
 });

--- a/tests/partials/ProjectCardSkeletonPartial.test.ts
+++ b/tests/partials/ProjectCardSkeletonPartial.test.ts
@@ -1,0 +1,27 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import ProjectCardSkeletonPartial from '@partials/ProjectCardSkeletonPartial.vue';
+
+describe('ProjectCardSkeletonPartial', () => {
+	it('renders animated wrapper by default', () => {
+		const wrapper = mount(ProjectCardSkeletonPartial);
+
+		expect(wrapper.classes()).toContain('animate-pulse');
+	});
+
+	it('merges custom wrapper classes', () => {
+		const wrapper = mount(ProjectCardSkeletonPartial, {
+			props: { wrapperClass: 'custom-class' },
+		});
+
+		expect(wrapper.classes()).toContain('custom-class');
+	});
+
+	it('disables animation when requested', () => {
+		const wrapper = mount(ProjectCardSkeletonPartial, {
+			props: { isAnimated: false },
+		});
+
+		expect(wrapper.classes()).not.toContain('animate-pulse');
+	});
+});

--- a/tests/partials/TalkCardSkeletonPartial.test.ts
+++ b/tests/partials/TalkCardSkeletonPartial.test.ts
@@ -1,0 +1,20 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import TalkCardSkeletonPartial from '@partials/TalkCardSkeletonPartial.vue';
+
+describe('TalkCardSkeletonPartial', () => {
+	it('applies animation by default', () => {
+		const wrapper = mount(TalkCardSkeletonPartial);
+
+		expect(wrapper.classes()).toContain('animate-pulse');
+		expect(wrapper.attributes('aria-hidden')).toBe('true');
+	});
+
+	it('respects disabled animation flag', () => {
+		const wrapper = mount(TalkCardSkeletonPartial, {
+			props: { isAnimated: false },
+		});
+
+		expect(wrapper.classes()).not.toContain('animate-pulse');
+	});
+});

--- a/tests/partials/TalkCardSkeletonPartial.test.ts
+++ b/tests/partials/TalkCardSkeletonPartial.test.ts
@@ -6,7 +6,7 @@ describe('TalkCardSkeletonPartial', () => {
 	it('applies animation by default', () => {
 		const wrapper = mount(TalkCardSkeletonPartial);
 
-		expect(wrapper.classes()).toContain('animate-pulse');
+		expect(wrapper.attributes('class')).toContain('animate-pulse');
 		expect(wrapper.attributes('aria-hidden')).toBe('true');
 	});
 
@@ -15,6 +15,6 @@ describe('TalkCardSkeletonPartial', () => {
 			props: { isAnimated: false },
 		});
 
-		expect(wrapper.classes()).not.toContain('animate-pulse');
+		expect(wrapper.attributes('class')).not.toContain('animate-pulse');
 	});
 });

--- a/tests/partials/WidgetSkillsSkeletonPartial.test.ts
+++ b/tests/partials/WidgetSkillsSkeletonPartial.test.ts
@@ -1,0 +1,22 @@
+import { mount } from '@vue/test-utils';
+import { describe, it, expect } from 'vitest';
+import WidgetSkillsSkeletonPartial from '@partials/WidgetSkillsSkeletonPartial.vue';
+
+describe('WidgetSkillsSkeletonPartial', () => {
+	it('renders six placeholder skill rows', () => {
+		const wrapper = mount(WidgetSkillsSkeletonPartial);
+		const items = wrapper.findAll('li');
+
+		expect(items).toHaveLength(6);
+		items.forEach((item) => {
+			expect(item.classes()).toContain('flex');
+		});
+	});
+
+	it('is marked as purely decorative', () => {
+		const wrapper = mount(WidgetSkillsSkeletonPartial);
+
+		expect(wrapper.attributes('aria-hidden')).toBeUndefined();
+		expect(wrapper.classes()).toContain('animate-pulse');
+	});
+});

--- a/tests/partials/WidgetSkillsSkeletonPartial.test.ts
+++ b/tests/partials/WidgetSkillsSkeletonPartial.test.ts
@@ -17,6 +17,6 @@ describe('WidgetSkillsSkeletonPartial', () => {
 		const wrapper = mount(WidgetSkillsSkeletonPartial);
 
 		expect(wrapper.attributes('aria-hidden')).toBeUndefined();
-		expect(wrapper.classes()).toContain('animate-pulse');
+		expect(wrapper.attributes('class')).toContain('animate-pulse');
 	});
 });


### PR DESCRIPTION
## Summary
- add Vitest coverage for the skeleton partial components to verify animation toggles and structural placeholders
- assert the post page skeleton exposes a stable test identifier

## Testing
- npm test *(fails: vitest binary not available in execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df7c594b988333a027318dff37dbf1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Expanded test coverage for skeleton UI components, validating default loading animations, the ability to disable animations, and non-interactive/accessibility semantics.
  - Verified correct rendering of placeholder elements and class handling (including custom class merging).
  - Ensures consistent visual behavior and accessibility of loading states across the app.
  - No user-facing changes; improves reliability and confidence in existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->