### PR TITLE
Draft: Adjust dark mode search focus ring

### DIFF
--- a/src/css/support/utility-patterns.css
+++ b/src/css/support/utility-patterns.css
@@ -64,7 +64,7 @@ input[type='search']::-webkit-search-results-decoration {
 .form-textarea,
 .form-multiselect,
 .form-select {
-	@apply bg-slate-100 dark:bg-slate-700 text-sm px-3 py-2 rounded-full focus:border-fuchsia-500 dark:border-slate-700 dark:focus:border-fuchsia-700 focus:ring-2 focus:ring-fuchsia-200 dark:focus:ring-0;
+	@apply bg-slate-100 dark:bg-slate-700 text-sm px-3 py-2 rounded-full focus:border-fuchsia-500 dark:border-slate-700 dark:focus:border-fuchsia-700 focus:ring-2 focus:ring-fuchsia-200 dark:focus:ring-2 dark:focus:ring-fuchsia-900/40;
 }
 
 .form-input,


### PR DESCRIPTION
## Summary
- update the shared form control styles so dark mode search inputs receive a matching fuchsia focus ring

## Testing
- not run (node dependencies unavailable in the execution environment)

------
https://chatgpt.com/codex/tasks/task_e_68df8fa8922c833392fe031c6a72a568