### PR TITLE
feat: Add back-to-top links to resume sections

### DIFF
--- a/src/pages/ResumePage.vue
+++ b/src/pages/ResumePage.vue
@@ -15,7 +15,7 @@
 							<div class="max-w-[700px]">
 								<section>
 									<!-- Page title -->
-									<h1 class="h1 font-aspekta mb-6">My resume</h1>
+									<h1 id="resume-top" class="h1 font-aspekta mb-6">My resume</h1>
 
 									<nav aria-label="Resume sections" class="flex flex-wrap items-center gap-3 text-sm font-medium text-slate-500 dark:text-slate-400 mb-12">
 										<a

--- a/src/partials/BackToTopLink.vue
+++ b/src/partials/BackToTopLink.vue
@@ -1,0 +1,9 @@
+<template>
+	<a
+		class="inline-flex items-center gap-2 rounded-full border border-slate-200/70 px-4 py-2 text-sm font-medium text-slate-600 transition-colors hover:border-fuchsia-400/70 hover:text-slate-800 dark:border-slate-700/80 dark:text-slate-300 dark:hover:text-slate-100"
+		href="#resume-top"
+	>
+		<span aria-hidden="true">↑</span>
+		Back to top
+	</a>
+</template>

--- a/src/partials/ExperiencePartial.vue
+++ b/src/partials/ExperiencePartial.vue
@@ -2,13 +2,7 @@
 	<section class="space-y-8">
 		<div class="flex flex-wrap items-center justify-between gap-4">
 			<h2 class="h2 font-aspekta text-slate-700 dark:text-slate-300">Work Experience</h2>
-			<a
-				class="inline-flex items-center gap-2 rounded-full border border-slate-200/70 px-4 py-2 text-sm font-medium text-slate-600 transition-colors hover:border-fuchsia-400/70 hover:text-slate-800 dark:border-slate-700/80 dark:text-slate-300 dark:hover:text-slate-100"
-				href="#resume-top"
-			>
-				<span aria-hidden="true">↑</span>
-				Back to top
-			</a>
+			<BackToTopLink />
 		</div>
 		<ul class="space-y-8">
 			<!-- Item -->
@@ -49,6 +43,7 @@
 	</section>
 </template>
 <script setup lang="ts">
+import BackToTopLink from '@partials/BackToTopLink.vue';
 import type { ExperienceResponse } from '@api/response/index.ts';
 
 const props = defineProps<{

--- a/src/partials/ExperiencePartial.vue
+++ b/src/partials/ExperiencePartial.vue
@@ -1,6 +1,15 @@
 <template>
 	<section class="space-y-8">
-		<h2 class="h2 font-aspekta text-slate-700 dark:text-slate-300">Work Experience</h2>
+		<div class="flex flex-wrap items-center justify-between gap-4">
+			<h2 class="h2 font-aspekta text-slate-700 dark:text-slate-300">Work Experience</h2>
+			<a
+				class="inline-flex items-center gap-2 rounded-full border border-slate-200/70 px-4 py-2 text-sm font-medium text-slate-600 transition-colors hover:border-fuchsia-400/70 hover:text-slate-800 dark:border-slate-700/80 dark:text-slate-300 dark:hover:text-slate-100"
+				href="#resume-top"
+			>
+				<span aria-hidden="true">↑</span>
+				Back to top
+			</a>
+		</div>
 		<ul class="space-y-8">
 			<!-- Item -->
 			<li v-for="item in props.experience" :key="item.uuid" class="relative group">

--- a/src/partials/RecommendationPartial.vue
+++ b/src/partials/RecommendationPartial.vue
@@ -2,13 +2,7 @@
 	<section class="space-y-8">
 		<div class="flex flex-wrap items-center justify-between gap-4">
 			<h2 class="h3 font-aspekta text-slate-800 dark:text-slate-100">Recommendations</h2>
-			<a
-				class="inline-flex items-center gap-2 rounded-full border border-slate-200/70 px-4 py-2 text-sm font-medium text-slate-600 transition-colors hover:border-fuchsia-400/70 hover:text-slate-800 dark:border-slate-700/80 dark:text-slate-300 dark:hover:text-slate-100"
-				href="#resume-top"
-			>
-				<span aria-hidden="true">↑</span>
-				Back to top
-			</a>
+			<BackToTopLink />
 		</div>
 		<ul class="space-y-8">
 			<!-- Item -->
@@ -38,6 +32,7 @@
 <script setup lang="ts">
 import { computed } from 'vue';
 import DOMPurify from 'dompurify';
+import BackToTopLink from '@partials/BackToTopLink.vue';
 import { image, date } from '@/public.ts';
 import type { RecommendationsResponse } from '@api/response/recommendations-response.ts';
 import { renderMarkdown } from '@/support/markdown.ts';

--- a/src/partials/RecommendationPartial.vue
+++ b/src/partials/RecommendationPartial.vue
@@ -1,6 +1,15 @@
 <template>
 	<section class="space-y-8">
-		<h2 class="h3 font-aspekta text-slate-800 dark:text-slate-100">Recommendations</h2>
+		<div class="flex flex-wrap items-center justify-between gap-4">
+			<h2 class="h3 font-aspekta text-slate-800 dark:text-slate-100">Recommendations</h2>
+			<a
+				class="inline-flex items-center gap-2 rounded-full border border-slate-200/70 px-4 py-2 text-sm font-medium text-slate-600 transition-colors hover:border-fuchsia-400/70 hover:text-slate-800 dark:border-slate-700/80 dark:text-slate-300 dark:hover:text-slate-100"
+				href="#resume-top"
+			>
+				<span aria-hidden="true">↑</span>
+				Back to top
+			</a>
+		</div>
 		<ul class="space-y-8">
 			<!-- Item -->
 			<li v-for="item in processedRecommendations" :key="item.uuid" class="relative group">


### PR DESCRIPTION
## Summary
- add a resume page anchor that serves as the destination for back-to-top controls
- show back-to-top buttons beside the work experience and recommendations section headers while keeping education unchanged

## Testing
- `make format`
- `npm test -- --runInBand` *(fails: vitest not found in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68df8f77047483339f5a5a624d15ada1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Back to top” links in the Work Experience and Recommendations section headers for quicker navigation.
  * The main resume title now supports anchor linking to the top, enabling direct jumps back to the start of the resume.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->