### PR TITLE
fix: Align article list skeleton thumbnail dimensions

### DIFF
--- a/src/partials/ArticleItemPartial.vue
+++ b/src/partials/ArticleItemPartial.vue
@@ -3,7 +3,7 @@
 		<div class="flex items-start">
 			<router-link
 				v-lazy-link
-				class="relative block aspect-square w-20 h-20 sm:w-28 sm:h-28 mr-4 sm:mr-6 overflow-hidden rounded-lg bg-slate-200/80 dark:bg-slate-800/80 flex-shrink-0 cursor-pointer shadow-sm ring-1 ring-inset ring-slate-200/70 dark:ring-slate-700/70"
+				class="relative block aspect-square w-20 sm:w-28 mr-4 sm:mr-6 overflow-hidden rounded-lg bg-slate-200/80 dark:bg-slate-800/80 flex-shrink-0 cursor-pointer shadow-sm ring-1 ring-inset ring-slate-200/70 dark:ring-slate-700/70"
 				:class="isImageError ? 'animate-none' : showSkeleton ? 'animate-pulse' : 'animate-none'"
 				:to="{ name: 'PostDetail', params: { slug: item.slug } }"
 			>

--- a/src/partials/ArticleItemSkeletonPartial.vue
+++ b/src/partials/ArticleItemSkeletonPartial.vue
@@ -1,7 +1,9 @@
 <template>
 	<article class="py-5 border-b border-slate-100 dark:border-slate-800" :class="animationClass" aria-hidden="true">
 		<div class="flex items-start">
-			<div class="relative block rounded-sm w-16 h-16 sm:w-[88px] sm:h-[88px] mr-6 overflow-hidden bg-slate-200 dark:bg-slate-800 flex-shrink-0"></div>
+			<div
+				class="relative block aspect-square w-20 h-20 sm:w-28 sm:h-28 mr-4 sm:mr-6 overflow-hidden rounded-lg bg-slate-200/80 dark:bg-slate-800/80 flex-shrink-0 shadow-sm ring-1 ring-inset ring-slate-200/70 dark:ring-slate-700/70"
+			></div>
 			<div class="flex-1 space-y-3">
 				<div class="h-3 w-28 bg-slate-200 dark:bg-slate-700 rounded"></div>
 				<div class="h-5 w-3/4 bg-slate-200 dark:bg-slate-700 rounded"></div>

--- a/src/partials/ArticleItemSkeletonPartial.vue
+++ b/src/partials/ArticleItemSkeletonPartial.vue
@@ -2,7 +2,7 @@
 	<article class="py-5 border-b border-slate-100 dark:border-slate-800" :class="animationClass" aria-hidden="true">
 		<div class="flex items-start">
 			<div
-				class="relative block aspect-square w-20 h-20 sm:w-28 sm:h-28 mr-4 sm:mr-6 overflow-hidden rounded-lg bg-slate-200/80 dark:bg-slate-800/80 flex-shrink-0 shadow-sm ring-1 ring-inset ring-slate-200/70 dark:ring-slate-700/70"
+				class="relative block aspect-square w-20 sm:w-28 mr-4 sm:mr-6 overflow-hidden rounded-lg bg-slate-200/80 dark:bg-slate-800/80 flex-shrink-0 shadow-sm ring-1 ring-inset ring-slate-200/70 dark:ring-slate-700/70"
 			></div>
 			<div class="flex-1 space-y-3">
 				<div class="h-3 w-28 bg-slate-200 dark:bg-slate-700 rounded"></div>


### PR DESCRIPTION
## Summary
- update the article list skeleton thumbnail container to match the live article card sizing and spacing
- retain the pulse animation while preventing layout shift when real content loads

## Testing
- npm test -- --runInBand *(fails: vitest not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e32b0d6fd88333862d0867b492bbc7