### PR TITLE
Add Oullin information widget to homepage

### DIFF
--- a/src/pages/HomePage.vue
+++ b/src/pages/HomePage.vue
@@ -25,6 +25,7 @@
 						<!-- Right sidebar -->
 						<aside class="md:w-[240px] lg:w-[300px] shrink-0">
 							<div class="space-y-6">
+								<WidgetOullinPartial />
 								<WidgetSponsorPartial />
 								<WidgetSkillsSkeletonPartial v-if="isLoadingProfile || !profile" />
 								<WidgetSkillsPartial v-else :skills="profile.skills" />
@@ -50,6 +51,7 @@ import ArticlesListPartial from '@partials/ArticlesListPartial.vue';
 import WidgetSponsorPartial from '@partials/WidgetSponsorPartial.vue';
 import FeaturedProjectsPartial from '@partials/FeaturedProjectsPartial.vue';
 import WidgetSkillsSkeletonPartial from '@partials/WidgetSkillsSkeletonPartial.vue';
+import WidgetOullinPartial from '@partials/WidgetOullinPartial.vue';
 
 import { onMounted, ref } from 'vue';
 import { useApiStore } from '@api/store.ts';

--- a/src/partials/WidgetOullinPartial.vue
+++ b/src/partials/WidgetOullinPartial.vue
@@ -1,0 +1,95 @@
+<template>
+	<div class="rounded-lg border border-slate-200 bg-white p-5 shadow-sm dark:border-slate-800 dark:bg-linear-to-t dark:from-slate-800 dark:to-slate-800/30">
+		<div class="font-aspekta text-sm font-[650] uppercase tracking-wide text-slate-500 dark:text-slate-400">What's Oullin?</div>
+		<p class="mt-2 text-sm text-slate-600 dark:text-slate-300">
+			In Aztec tradition, Ollin means “movement” or “motion,” embodying transformation, heart, life, and the calendar’s purified spirit-day. But Ollin goes deeper—it speaks to the same gentle
+			momentum at the heart of Zen, where each breath, each step, is a flowing wave of presence.
+		</p>
+		<button
+			type="button"
+			class="mt-3 inline-flex items-center text-sm font-medium text-sky-600 hover:text-sky-500 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:text-sky-400 dark:hover:text-sky-300"
+			@click="openDialog"
+		>
+			Read more
+		</button>
+	</div>
+
+	<Teleport to="body">
+		<Transition name="fade">
+			<div v-if="isDialogOpen" class="fixed inset-0 z-50 flex items-center justify-center p-4">
+				<div class="absolute inset-0 bg-slate-900/70" @click="closeDialog" />
+
+				<div
+					class="relative max-h-[85vh] w-full max-w-2xl overflow-y-auto rounded-xl bg-white p-6 shadow-xl dark:bg-slate-900"
+					role="dialog"
+					aria-modal="true"
+					aria-labelledby="oullin-dialog-title"
+				>
+					<div class="flex items-start justify-between">
+						<h2 id="oullin-dialog-title" class="text-xl font-semibold text-slate-900 dark:text-white">What's Oullin?</h2>
+						<button
+							type="button"
+							class="ml-4 text-slate-400 transition hover:text-slate-600 focus:outline-none focus-visible:ring-2 focus-visible:ring-sky-500 focus-visible:ring-offset-2 dark:text-slate-500 dark:hover:text-slate-300"
+							@click="closeDialog"
+						>
+							<span class="sr-only">Close</span>
+							<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" class="h-5 w-5">
+								<path
+									fill-rule="evenodd"
+									d="M10 8.586 4.95 3.536A1 1 0 1 0 3.536 4.95L8.586 10l-5.05 5.05a1 1 0 0 0 1.414 1.414L10 11.414l5.05 5.05a1 1 0 0 0 1.414-1.414L11.414 10l5.05-5.05A1 1 0 0 0 15.05 3.536L10 8.586Z"
+									clip-rule="evenodd"
+								/>
+							</svg>
+						</button>
+					</div>
+
+					<div class="mt-4 space-y-4 text-base leading-relaxed text-slate-700 dark:text-slate-200">
+						<p>
+							In Aztec tradition, Ollin means “movement” or “motion,” embodying transformation, heart, life, and the calendar’s purified spirit-day. But Ollin goes deeper—it speaks to
+							the same gentle momentum at the heart of Zen, where each breath, each step, is a flowing wave of presence.
+						</p>
+						<p>
+							For anyone on the path of self-discovery, Ollin becomes a guide: it reminds us to move with intention, stay grounded in the here and now, and welcome life’s shifts as
+							chances to grow.
+						</p>
+						<p>
+							Just as Zen teaches us to let thoughts pass like clouds, Ollin’s energy urges us to embrace change—transforming every action into a moment of awareness, renewal, and
+							wholehearted living.
+						</p>
+						<p>
+							With this organisation’s name, whether it’s spelled oullin or ollin, or another fun variant. I am deliberately riffing on the Aztec Ollin to weave “movement,”
+							transformation, and mindful flow right into my identity. That little twist in spelling isn’t just for show; it’s a daily nudge to stay present, move with purpose, and
+							welcome every change as part of my shared journey.
+						</p>
+					</div>
+				</div>
+			</div>
+		</Transition>
+	</Teleport>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue';
+
+const isDialogOpen = ref(false);
+
+const openDialog = () => {
+	isDialogOpen.value = true;
+};
+
+const closeDialog = () => {
+	isDialogOpen.value = false;
+};
+</script>
+
+<style scoped>
+.fade-enter-active,
+.fade-leave-active {
+	transition: opacity 0.2s ease;
+}
+
+.fade-enter-from,
+.fade-leave-to {
+	opacity: 0;
+}
+</style>

--- a/tests/partials/WidgetOullinPartial.test.ts
+++ b/tests/partials/WidgetOullinPartial.test.ts
@@ -1,0 +1,30 @@
+import { mount } from '@vue/test-utils';
+import { afterEach, describe, expect, it } from 'vitest';
+import WidgetOullinPartial from '@partials/WidgetOullinPartial.vue';
+
+afterEach(() => {
+	document.body.innerHTML = '';
+});
+
+describe('WidgetOullinPartial', () => {
+	it('renders intro text', () => {
+		const wrapper = mount(WidgetOullinPartial);
+		expect(wrapper.text()).toContain("What's Oullin?");
+		expect(wrapper.text()).toContain('In Aztec tradition, Ollin means “movement” or “motion,” embodying transformation');
+		wrapper.unmount();
+	});
+
+	it('opens and closes the dialog when interacting with the read more link', async () => {
+		const wrapper = mount(WidgetOullinPartial, { attachTo: document.body });
+
+		await wrapper.get('button').trigger('click');
+
+		expect(document.body.textContent).toContain('For anyone on the path of self-discovery, Ollin becomes a guide');
+
+		const closeButton = wrapper.findAll('button')[1];
+		await closeButton.trigger('click');
+
+		expect(document.body.textContent).not.toContain('For anyone on the path of self-discovery, Ollin becomes a guide');
+		wrapper.unmount();
+	});
+});


### PR DESCRIPTION
## Summary
- add a new Oullin widget on the home page ahead of the sponsor widget
- provide a modal dialog with the full Oullin narrative and accessible controls
- cover the widget with unit tests for rendering and dialog interactions

## Testing
- npm run test *(fails: vitest: not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3833655208333bd566d46e36700d3