### PR TITLE
Add hover-controlled grayscale effect to article list images

### DIFF
--- a/src/partials/ArticleItemPartial.vue
+++ b/src/partials/ArticleItemPartial.vue
@@ -1,7 +1,11 @@
 <template>
-	<article v-if="item" class="py-5 border-b border-slate-100 dark:border-slate-800">
+	<article v-if="item" class="py-5 border-b border-slate-100 dark:border-slate-800 group">
 		<div class="flex items-start">
-			<router-link v-lazy-link class="relative block mr-4 sm:mr-6 flex-shrink-0 cursor-pointer" :to="{ name: 'PostDetail', params: { slug: item.slug } }">
+			<router-link
+				v-lazy-link
+				class="relative block mr-4 sm:mr-6 flex-shrink-0 cursor-pointer grayscale transition duration-300 ease-out group-hover:grayscale-0 group-focus-within:grayscale-0 hover:grayscale-0 focus-visible:grayscale-0"
+				:to="{ name: 'PostDetail', params: { slug: item.slug } }"
+			>
 				<CoverImageLoader
 					class="block aspect-square w-20 sm:w-28 overflow-hidden rounded-lg bg-slate-200/80 dark:bg-slate-800/80 shadow-sm ring-1 ring-inset ring-slate-200/70 dark:ring-slate-700/70"
 					:src="item.cover_image_url"

--- a/tests/partials/ArticleItemPartial.test.ts
+++ b/tests/partials/ArticleItemPartial.test.ts
@@ -46,6 +46,13 @@ describe('ArticleItemPartial', () => {
 		expect(coverLoader.exists()).toBe(true);
 		expect(coverLoader.props('src')).toBe(item.cover_image_url);
 		expect(coverLoader.props('alt')).toBe(item.title);
+
+		const article = wrapper.find('article');
+		expect(article.classes()).toContain('group');
+
+		const links = wrapper.findAll('a');
+		const imageLink = links[0];
+		expect(imageLink.classes()).toEqual(expect.arrayContaining(['grayscale', 'group-hover:grayscale-0', 'group-focus-within:grayscale-0', 'hover:grayscale-0', 'focus-visible:grayscale-0']));
 	});
 
 	it('relies on the cover loader placeholder when no image url is provided', () => {


### PR DESCRIPTION
## Summary
- gray out article list cover images by default and restore full color when the article item, its image, or its title is hovered or focused
- update the article item test suite to capture the new grayscale classes and grouping

## Testing
- make format
- npm test *(fails: vitest not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e4c3be4aa483339d43a4b35861c83d