### PR TITLE
Simulate hover animation for article titles

### DIFF
--- a/src/partials/ArticleItemPartial.vue
+++ b/src/partials/ArticleItemPartial.vue
@@ -40,7 +40,7 @@
 				<h3 class="text-slate-700 font-aspekta text-lg font-[650] mb-1 dark:text-slate-300">
 					<router-link
 						v-lazy-link
-						class="inline-flex relative hover:text-fuchsia-500 dark:hover:text-teal-500 duration-150 ease-out before:scale-x-0 before:origin-center before:absolute before:inset-0 before:bg-sky-200 dark:before:bg-sky-500 before:opacity-30 before:-z-10 before:translate-y-1/4 before:-rotate-2 hover:before:scale-100 before:duration-150 before:ease-in-out"
+						class="inline-flex relative hover:text-fuchsia-500 dark:hover:text-teal-500 group-hover:text-fuchsia-500 dark:group-hover:text-teal-500 duration-150 ease-out before:scale-x-0 before:origin-center before:absolute before:inset-0 before:bg-sky-200 dark:before:bg-sky-500 before:opacity-30 before:-z-10 before:translate-y-1/4 before:-rotate-2 hover:before:scale-100 group-hover:before:scale-100 before:duration-150 before:ease-in-out"
 						:to="{ name: 'PostDetail', params: { slug: item.slug } }"
 					>
 						{{ item.title }}

--- a/src/partials/ArticleItemPartial.vue
+++ b/src/partials/ArticleItemPartial.vue
@@ -38,11 +38,7 @@
 					{{ date().format(new Date(item.published_at)) }}
 				</div>
 				<h3 class="text-slate-700 font-aspekta text-lg font-[650] mb-1 dark:text-slate-300">
-					<router-link
-						v-lazy-link
-						class="inline-flex relative hover:text-fuchsia-500 dark:hover:text-teal-500 group-hover:text-fuchsia-500 dark:group-hover:text-teal-500 duration-150 ease-out before:scale-x-0 before:origin-center before:absolute before:inset-0 before:bg-sky-200 dark:before:bg-sky-500 before:opacity-30 before:-z-10 before:translate-y-1/4 before:-rotate-2 hover:before:scale-100 group-hover:before:scale-100 before:duration-150 before:ease-in-out"
-						:to="{ name: 'PostDetail', params: { slug: item.slug } }"
-					>
+					<router-link v-lazy-link :class="titleLinkClass" :to="{ name: 'PostDetail', params: { slug: item.slug } }">
 						{{ item.title }}
 					</router-link>
 				</h3>
@@ -70,6 +66,9 @@
 import CoverImageLoader from '@components/CoverImageLoader.vue';
 import { date } from '@/public.ts';
 import type { PostResponse } from '@api/response/index.ts';
+
+const titleLinkClass =
+	'inline-flex relative hover:text-fuchsia-500 dark:hover:text-teal-500 group-hover:text-fuchsia-500 dark:group-hover:text-teal-500 duration-150 ease-out before:scale-x-0 before:origin-center before:absolute before:inset-0 before:bg-sky-200 dark:before:bg-sky-500 before:opacity-30 before:-z-10 before:translate-y-1/4 before:-rotate-2 hover:before:scale-100 group-hover:before:scale-100 before:duration-150 before:ease-in-out';
 
 defineProps<{
 	item: PostResponse;

--- a/src/partials/ArticleItemPartial.vue
+++ b/src/partials/ArticleItemPartial.vue
@@ -68,7 +68,7 @@ import { date } from '@/public.ts';
 import type { PostResponse } from '@api/response/index.ts';
 
 const titleLinkClass =
-	'inline-flex relative hover:text-fuchsia-500 dark:hover:text-teal-500 group-hover:text-fuchsia-500 dark:group-hover:text-teal-500 duration-150 ease-out before:scale-x-0 before:origin-center before:absolute before:inset-0 before:bg-sky-200 dark:before:bg-sky-500 before:opacity-30 before:-z-10 before:translate-y-1/4 before:-rotate-2 hover:before:scale-100 group-hover:before:scale-100 before:duration-150 before:ease-in-out';
+	'inline-flex relative group-hover:text-fuchsia-500 dark:group-hover:text-teal-500 duration-150 ease-out before:scale-x-0 before:origin-center before:absolute before:inset-0 before:bg-sky-200 dark:before:bg-sky-500 before:opacity-30 before:-z-10 before:translate-y-1/4 before:-rotate-2 group-hover:before:scale-100 before:duration-150 before:ease-in-out';
 
 defineProps<{
 	item: PostResponse;

--- a/src/partials/ArticleItemPartial.vue
+++ b/src/partials/ArticleItemPartial.vue
@@ -3,7 +3,7 @@
 		<div class="flex items-start">
 			<router-link
 				v-lazy-link
-				class="relative block mr-4 sm:mr-6 flex-shrink-0 cursor-pointer grayscale transition duration-300 ease-out group-hover:grayscale-0 group-focus-within:grayscale-0"
+				class="relative block mr-4 sm:mr-6 flex-shrink-0 cursor-pointer grayscale-[65%] transition duration-300 ease-out group-hover:grayscale-0 group-focus-within:grayscale-0"
 				:to="{ name: 'PostDetail', params: { slug: item.slug } }"
 			>
 				<CoverImageLoader

--- a/src/partials/ArticleItemPartial.vue
+++ b/src/partials/ArticleItemPartial.vue
@@ -34,7 +34,7 @@
 				</CoverImageLoader>
 			</router-link>
 			<div>
-				<div class="text-xs text-slate-700 uppercase mb-1 dark:text-slate-500">
+				<div class="text-xs text-fuchsia-500 uppercase mb-1 dark:text-teal-500">
 					{{ date().format(new Date(item.published_at)) }}
 				</div>
 				<h3 class="text-slate-700 font-aspekta text-lg font-[650] mb-1 dark:text-slate-300">

--- a/tests/partials/ArticleItemPartial.test.ts
+++ b/tests/partials/ArticleItemPartial.test.ts
@@ -55,7 +55,7 @@ describe('ArticleItemPartial', () => {
 
 		const links = wrapper.findAll('a');
 		const imageLink = links[0];
-		expect(imageLink.classes()).toEqual(expect.arrayContaining(['grayscale', 'group-hover:grayscale-0', 'group-focus-within:grayscale-0']));
+		expect(imageLink.classes()).toEqual(expect.arrayContaining(['grayscale-[65%]', 'group-hover:grayscale-0', 'group-focus-within:grayscale-0']));
 
 		const titleLink = links[1];
 		expect(titleLink.classes()).toEqual(expect.arrayContaining(['group-hover:text-fuchsia-500', 'dark:group-hover:text-teal-500', 'group-hover:before:scale-100']));

--- a/tests/partials/ArticleItemPartial.test.ts
+++ b/tests/partials/ArticleItemPartial.test.ts
@@ -42,6 +42,9 @@ describe('ArticleItemPartial', () => {
 		expect(wrapper.text()).toContain('formatted');
 		expect(wrapper.text()).toContain(item.title);
 
+		const dateText = wrapper.find('.text-xs');
+		expect(dateText.classes()).toEqual(expect.arrayContaining(['text-fuchsia-500', 'dark:text-teal-500']));
+
 		const coverLoader = wrapper.findComponent(CoverImageLoader);
 		expect(coverLoader.exists()).toBe(true);
 		expect(coverLoader.props('src')).toBe(item.cover_image_url);

--- a/tests/partials/ArticleItemPartial.test.ts
+++ b/tests/partials/ArticleItemPartial.test.ts
@@ -53,6 +53,18 @@ describe('ArticleItemPartial', () => {
 		const links = wrapper.findAll('a');
 		const imageLink = links[0];
 		expect(imageLink.classes()).toEqual(expect.arrayContaining(['grayscale', 'group-hover:grayscale-0', 'group-focus-within:grayscale-0']));
+
+		const titleLink = links[1];
+		expect(titleLink.classes()).toEqual(
+			expect.arrayContaining([
+				'hover:text-fuchsia-500',
+				'dark:hover:text-teal-500',
+				'group-hover:text-fuchsia-500',
+				'dark:group-hover:text-teal-500',
+				'hover:before:scale-100',
+				'group-hover:before:scale-100',
+			]),
+		);
 	});
 
 	it('relies on the cover loader placeholder when no image url is provided', () => {

--- a/tests/partials/ArticleItemPartial.test.ts
+++ b/tests/partials/ArticleItemPartial.test.ts
@@ -58,16 +58,7 @@ describe('ArticleItemPartial', () => {
 		expect(imageLink.classes()).toEqual(expect.arrayContaining(['grayscale', 'group-hover:grayscale-0', 'group-focus-within:grayscale-0']));
 
 		const titleLink = links[1];
-		expect(titleLink.classes()).toEqual(
-			expect.arrayContaining([
-				'hover:text-fuchsia-500',
-				'dark:hover:text-teal-500',
-				'group-hover:text-fuchsia-500',
-				'dark:group-hover:text-teal-500',
-				'hover:before:scale-100',
-				'group-hover:before:scale-100',
-			]),
-		);
+		expect(titleLink.classes()).toEqual(expect.arrayContaining(['group-hover:text-fuchsia-500', 'dark:group-hover:text-teal-500', 'group-hover:before:scale-100']));
 	});
 
 	it('relies on the cover loader placeholder when no image url is provided', () => {


### PR DESCRIPTION
## Summary
- trigger the article title hover styling when the entire article item is hovered
- extend the ArticleItemPartial unit test to cover the new group-hover styling classes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Style
  - Enhanced article title link styling with group-hover and related variants for more consistent hover/focus behavior.
  - Improved transitions and before-element effects and refined dark mode interaction states for smoother, more consistent visuals.

- Tests
  - Added assertions to validate new hover/group-hover and before-element transition classes and dark-mode styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->