### PR TITLE
fix: Resume layout skeleton handling

### DIFF
--- a/src/pages/ResumePage.vue
+++ b/src/pages/ResumePage.vue
@@ -31,7 +31,7 @@
 									<!-- Page content -->
 									<div class="text-slate-500 dark:text-slate-400">
 										<div v-if="shouldShowSkeleton" :class="['space-y-12', resumeSectionsTotalHeight]">
-											<ResumePageSkeletonPartial />
+											<ResumePageSkeletonPartial :show-refresh-button="hasProfileError" @retry="refreshResumePage" />
 										</div>
 										<div v-else class="space-y-12">
 											<div :class="resumeSectionHeights.education">
@@ -161,4 +161,10 @@ onMounted(async () => {
 		isLoadingProfile.value = false;
 	}
 });
+
+const refreshResumePage = () => {
+	if (typeof window !== 'undefined') {
+		window.location.reload();
+	}
+};
 </script>

--- a/src/pages/ResumePage.vue
+++ b/src/pages/ResumePage.vue
@@ -29,21 +29,24 @@
 										</a>
 									</nav>
 									<!-- Page content -->
-									<div class="text-slate-500 dark:text-slate-400 space-y-12">
-										<ResumePageSkeletonPartial v-if="isLoadingProfile" :class="resumeSectionsTotalHeight" />
-										<template v-else>
-											<span id="education" class="block h-0" aria-hidden="true"></span>
-											<EducationPartial v-if="education" :education="education" :class="resumeSectionHeights.education" />
-											<span id="experience" class="block h-0" aria-hidden="true"></span>
-											<ExperiencePartial v-if="experience" :experience="experience" back-to-top-target="#resume-top" :class="resumeSectionHeights.experience" />
-											<span id="recommendations" class="block h-0" aria-hidden="true"></span>
-											<RecommendationPartial
-												v-if="recommendations"
-												:recommendations="recommendations"
-												back-to-top-target="#resume-top"
-												:class="resumeSectionHeights.recommendations"
-											/>
-										</template>
+									<div class="text-slate-500 dark:text-slate-400">
+										<div v-if="shouldShowSkeleton" :class="['space-y-12', resumeSectionsTotalHeight]">
+											<ResumePageSkeletonPartial />
+										</div>
+										<div v-else class="space-y-12">
+											<div :class="resumeSectionHeights.education">
+												<span id="education" class="block h-0" aria-hidden="true"></span>
+												<EducationPartial v-if="education" :education="education" />
+											</div>
+											<div :class="resumeSectionHeights.experience">
+												<span id="experience" class="block h-0" aria-hidden="true"></span>
+												<ExperiencePartial v-if="experience" :experience="experience" back-to-top-target="#resume-top" />
+											</div>
+											<div :class="resumeSectionHeights.recommendations">
+												<span id="recommendations" class="block h-0" aria-hidden="true"></span>
+												<RecommendationPartial v-if="recommendations" :recommendations="recommendations" back-to-top-target="#resume-top" />
+											</div>
+										</div>
 									</div>
 									<div class="flex justify-end pt-10">
 										<BackToTopLink target="#resume-top" />
@@ -82,7 +85,7 @@ import WidgetSkillsSkeletonPartial from '@partials/WidgetSkillsSkeletonPartial.v
 import RecommendationPartial from '@partials/RecommendationPartial.vue';
 import ResumePageSkeletonPartial from '@partials/ResumePageSkeletonPartial.vue';
 
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, computed } from 'vue';
 import { useApiStore } from '@api/store.ts';
 import { debugError } from '@api/http-error.ts';
 import { useSeo, SITE_NAME, ABOUT_IMAGE, siteUrlFor, buildKeywords, PERSON_JSON_LD } from '@/support/seo';
@@ -102,6 +105,8 @@ const resumeSectionsTotalHeight = Heights.resumeSectionsTotalHeight();
 const apiStore = useApiStore();
 const profile = ref<ProfileResponse | null>(null);
 const isLoadingProfile = ref(true);
+const hasProfileError = ref(false);
+const shouldShowSkeleton = computed(() => isLoadingProfile.value || hasProfileError.value);
 const education = ref<EducationResponse[] | null>(null);
 const experience = ref<ExperienceResponse[] | null>(null);
 const recommendations = ref<RecommendationsResponse[] | null>(null);
@@ -151,6 +156,7 @@ onMounted(async () => {
 		}
 	} catch (error) {
 		debugError(error);
+		hasProfileError.value = true;
 	} finally {
 		isLoadingProfile.value = false;
 	}

--- a/src/partials/ResumePageSkeletonPartial.vue
+++ b/src/partials/ResumePageSkeletonPartial.vue
@@ -1,5 +1,5 @@
 <template>
-	<div data-testid="resume-page-skeleton" class="space-y-12 animate-pulse" aria-hidden="true">
+	<div data-testid="resume-page-skeleton" class="space-y-12 animate-pulse" :aria-hidden="showRefreshButton ? 'false' : 'true'">
 		<section class="space-y-8">
 			<h2 class="h3 font-aspekta text-slate-800 dark:text-slate-100">Education</h2>
 			<ul class="space-y-8">
@@ -75,5 +75,20 @@
 				</li>
 			</ul>
 		</section>
+		<div v-if="showRefreshButton" class="flex justify-center pt-4">
+			<button type="button" class="btn bg-fuchsia-500 hover:bg-fuchsia-600 text-white shadow-sm" @click="emit('retry')">Refresh page</button>
+		</div>
 	</div>
 </template>
+
+<script setup lang="ts">
+import { toRef, withDefaults } from 'vue';
+
+const props = withDefaults(defineProps<{ showRefreshButton?: boolean }>(), {
+	showRefreshButton: false,
+});
+
+const emit = defineEmits<{ (event: 'retry'): void }>();
+
+const showRefreshButton = toRef(props, 'showRefreshButton');
+</script>

--- a/tests/pages/ResumePage.test.ts
+++ b/tests/pages/ResumePage.test.ts
@@ -131,7 +131,11 @@ describe('ResumePage', () => {
 	it('handles fetch failures', async () => {
 		const error = new Error('oops');
 		getProfile.mockRejectedValueOnce(error);
-		const reloadSpy = vi.spyOn(window.location, 'reload').mockImplementation(() => {});
+		const reloadSpy = vi.fn();
+		const mockLocation = Object.create(window.location);
+		mockLocation.reload = reloadSpy;
+		const locationGetSpy = vi.spyOn(window, 'location', 'get');
+		locationGetSpy.mockReturnValue(mockLocation);
 		const _wrapper = mount(ResumePage, {
 			global: {
 				stubs: {
@@ -164,6 +168,6 @@ describe('ResumePage', () => {
 		});
 		await refreshButton.trigger('click');
 		expect(reloadSpy).toHaveBeenCalled();
-		reloadSpy.mockRestore();
+		locationGetSpy.mockRestore();
 	});
 });

--- a/tests/pages/ResumePage.test.ts
+++ b/tests/pages/ResumePage.test.ts
@@ -116,9 +116,13 @@ describe('ResumePage', () => {
 
 		const skeleton = wrapper.find('[data-testid="resume-page-skeleton"]');
 		expect(skeleton.exists()).toBe(true);
+		const skeletonWrapper = skeleton.element.parentElement as HTMLElement | null;
+		if (!skeletonWrapper) {
+			throw new Error('Skeleton wrapper not found');
+		}
 		const heightClasses = Heights.resumeSectionsTotalHeight().split(' ');
 		heightClasses.forEach((className) => {
-			expect(skeleton.classes()).toContain(className);
+			expect(skeletonWrapper.classList.contains(className)).toBe(true);
 		});
 	});
 
@@ -142,5 +146,7 @@ describe('ResumePage', () => {
 		await flushPromises();
 		const { debugError } = await import('@api/http-error.ts');
 		expect(debugError).toHaveBeenCalledWith(error);
+		const skeleton = _wrapper.find('[data-testid="resume-page-skeleton"]');
+		expect(skeleton.exists()).toBe(true);
 	});
 });

--- a/tests/pages/ResumePage.test.ts
+++ b/tests/pages/ResumePage.test.ts
@@ -116,6 +116,8 @@ describe('ResumePage', () => {
 
 		const skeleton = wrapper.find('[data-testid="resume-page-skeleton"]');
 		expect(skeleton.exists()).toBe(true);
+		expect(skeleton.attributes('aria-hidden')).toBe('true');
+		expect(skeleton.find('button').exists()).toBe(false);
 		const skeletonWrapper = skeleton.element.parentElement as HTMLElement | null;
 		if (!skeletonWrapper) {
 			throw new Error('Skeleton wrapper not found');
@@ -129,6 +131,7 @@ describe('ResumePage', () => {
 	it('handles fetch failures', async () => {
 		const error = new Error('oops');
 		getProfile.mockRejectedValueOnce(error);
+		const reloadSpy = vi.spyOn(window.location, 'reload').mockImplementation(() => {});
 		const _wrapper = mount(ResumePage, {
 			global: {
 				stubs: {
@@ -148,6 +151,9 @@ describe('ResumePage', () => {
 		expect(debugError).toHaveBeenCalledWith(error);
 		const skeleton = _wrapper.find('[data-testid="resume-page-skeleton"]');
 		expect(skeleton.exists()).toBe(true);
+		expect(skeleton.attributes('aria-hidden')).toBe('false');
+		const refreshButton = skeleton.get('button');
+		expect(refreshButton.text()).toBe('Refresh page');
 		const skeletonWrapper = skeleton.element.parentElement as HTMLElement | null;
 		if (!skeletonWrapper) {
 			throw new Error('Skeleton wrapper not found');
@@ -156,5 +162,8 @@ describe('ResumePage', () => {
 		heightClasses.forEach((className) => {
 			expect(skeletonWrapper.classList.contains(className)).toBe(true);
 		});
+		await refreshButton.trigger('click');
+		expect(reloadSpy).toHaveBeenCalled();
+		reloadSpy.mockRestore();
 	});
 });

--- a/tests/pages/ResumePage.test.ts
+++ b/tests/pages/ResumePage.test.ts
@@ -132,10 +132,8 @@ describe('ResumePage', () => {
 		const error = new Error('oops');
 		getProfile.mockRejectedValueOnce(error);
 		const reloadSpy = vi.fn();
-		const mockLocation = Object.create(window.location);
-		mockLocation.reload = reloadSpy;
 		const locationGetSpy = vi.spyOn(window, 'location', 'get');
-		locationGetSpy.mockReturnValue(mockLocation);
+		locationGetSpy.mockReturnValue({ reload: reloadSpy } as Location);
 		const _wrapper = mount(ResumePage, {
 			global: {
 				stubs: {

--- a/tests/pages/ResumePage.test.ts
+++ b/tests/pages/ResumePage.test.ts
@@ -148,5 +148,13 @@ describe('ResumePage', () => {
 		expect(debugError).toHaveBeenCalledWith(error);
 		const skeleton = _wrapper.find('[data-testid="resume-page-skeleton"]');
 		expect(skeleton.exists()).toBe(true);
+		const skeletonWrapper = skeleton.element.parentElement as HTMLElement | null;
+		if (!skeletonWrapper) {
+			throw new Error('Skeleton wrapper not found');
+		}
+		const heightClasses = Heights.resumeSectionsTotalHeight().split(' ');
+		heightClasses.forEach((className) => {
+			expect(skeletonWrapper.classList.contains(className)).toBe(true);
+		});
 	});
 });


### PR DESCRIPTION
## Summary
- wrap resume sections with min-height containers to prevent layout shift when data loads
- show the resume skeleton fallback when API requests fail so the page never renders blank
- update resume page tests for the new structure and error handling expectations

## Testing
- npm test *(fails: vitest command unavailable in the environment)*
- make format

------
https://chatgpt.com/codex/tasks/task_e_68e6109592bc8333b93882a6b902d38f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Unified skeleton display for the resume page during loading and error states for a more consistent experience.
- Bug Fixes
  - Ensured the skeleton reliably appears when profile data fails to load.
  - Stabilized section heights for Education, Experience, and Recommendations to reduce layout shifts.
- Refactor
  - Simplified layout by consolidating skeleton and content rendering, reducing scattered conditional logic.
- Tests
  - Updated tests to validate wrapper classes and skeleton presence, with added null checks for robustness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->