### PR TITLE
Update engagement pricing and founder bio

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,12 @@
 					"logo": "https://oullin.io/brand/logo-touch.png",
 					"image": "https://oullin.io/brand/logo-touch.png",
 					"description": "Oullin is a boutique software engineering and architecture consultancy for startups and scale-ups navigating the AI era. AI architecture, modernisation, and resilient systems for regulated and high-trust environments.",
-					"sameAs": ["https://github.com/oullin"]
+					"sameAs": ["https://github.com/oullin"],
+					"founder": {
+						"@type": "Person",
+						"name": "Gustavo Ocanto",
+						"url": "https://gocanto.sh"
+					}
 				}
 			]
 		</script>

--- a/src/pages/AboutPage.vue
+++ b/src/pages/AboutPage.vue
@@ -16,7 +16,7 @@
 						<div class="page-panel-title">{{ sidebar.founder.name }}</div>
 						<p class="page-panel-copy">{{ sidebar.founder.copy }}</p>
 						<div class="mt-4">
-							<a v-lazy-link :href="sidebar.founder.linkUrl" target="_blank" rel="noopener noreferrer" class="blog-link">{{ sidebar.founder.linkLabel }}</a>
+							<a v-lazy-link :href="sidebar.founder.linkUrl" target="_blank" rel="me noopener noreferrer" class="blog-link">{{ sidebar.founder.linkLabel }}</a>
 						</div>
 					</div>
 					<div class="page-side-block">

--- a/src/pages/WorkWithUsPage.vue
+++ b/src/pages/WorkWithUsPage.vue
@@ -51,7 +51,7 @@
 									<span v-for="item in engagement.includes" :key="item">{{ item }}</span>
 								</div>
 								<p class="page-panel-copy mt-5"><strong>You leave with:</strong> {{ engagement.outcome }}</p>
-								<RouterLink :to="engagement.cta.to" class="blog-link mt-5 inline-block">{{ engagement.cta.label }}</RouterLink>
+								<RouterLink :to="engagement.cta.to" class="blog-link mt-5 inline-block" :aria-label="`More info about ${engagement.label}`">{{ engagement.cta.label }}</RouterLink>
 							</div>
 						</div>
 						<div class="page-editorial-sep"></div>

--- a/src/pages/WorkWithUsPage.vue
+++ b/src/pages/WorkWithUsPage.vue
@@ -51,8 +51,7 @@
 									<span v-for="item in engagement.includes" :key="item">{{ item }}</span>
 								</div>
 								<p class="page-panel-copy mt-5"><strong>You leave with:</strong> {{ engagement.outcome }}</p>
-								<p class="page-panel-copy mt-2">{{ engagement.price }}</p>
-								<RouterLink :to="engagement.cta.to" class="btn-primary mt-5 inline-block">{{ engagement.cta.label }}</RouterLink>
+								<RouterLink :to="engagement.cta.to" class="blog-link mt-5 inline-block">{{ engagement.cta.label }}</RouterLink>
 							</div>
 						</div>
 						<div class="page-editorial-sep"></div>

--- a/src/pages/WorkWithUsPage.vue
+++ b/src/pages/WorkWithUsPage.vue
@@ -51,7 +51,9 @@
 									<span v-for="item in engagement.includes" :key="item">{{ item }}</span>
 								</div>
 								<p class="page-panel-copy mt-5"><strong>You leave with:</strong> {{ engagement.outcome }}</p>
-								<RouterLink :to="engagement.cta.to" class="blog-link mt-5 inline-block" :aria-label="`More info about ${engagement.label}`">{{ engagement.cta.label }}</RouterLink>
+								<RouterLink :to="engagement.cta.to" class="blog-link mt-5 inline-block" :aria-label="`${engagement.cta.label} about ${engagement.label}`">{{
+									engagement.cta.label
+								}}</RouterLink>
 							</div>
 						</div>
 						<div class="page-editorial-sep"></div>

--- a/src/support/content-types.ts
+++ b/src/support/content-types.ts
@@ -30,6 +30,10 @@ export interface SiteContent {
 	organization: {
 		description: string;
 		sameAs: string[];
+		founder: {
+			name: string;
+			url: string;
+		};
 	};
 	nav: {
 		links: RouteLink[];

--- a/src/support/content-types.ts
+++ b/src/support/content-types.ts
@@ -204,7 +204,6 @@ export interface WorkWithUsPageContent {
 		includesLabel: string;
 		includes: string[];
 		outcome: string;
-		price: string;
 		cta: RouteLink;
 	}>;
 	faq: {

--- a/src/support/seo.ts
+++ b/src/support/seo.ts
@@ -26,6 +26,11 @@ export const ORGANIZATION_JSON_LD = {
 	image: siteUrlFor(SITE_LOGO),
 	description: siteContent.organization.description,
 	sameAs: siteContent.organization.sameAs,
+	founder: {
+		'@type': 'Person',
+		name: siteContent.organization.founder.name,
+		url: siteContent.organization.founder.url,
+	},
 };
 
 type TwitterCard = 'summary' | 'summary_large_image' | 'app' | 'player';

--- a/storage/fixtures/about-page.json
+++ b/storage/fixtures/about-page.json
@@ -12,8 +12,8 @@
 			"label": "// founder & lead architect",
 			"name": "Gustavo Ocanto",
 			"copy": "Engineering leader with 20+ years across software engineering, consulting, architecture, AI-first products and companies, and technical management. 10+ years in banking and fintech.",
-			"linkLabel": "LinkedIn Profile →",
-			"linkUrl": "https://www.linkedin.com/in/gocanto/"
+			"linkLabel": "Founder bio →",
+			"linkUrl": "https://gocanto.sh"
 		},
 		"proof": {
 			"label": "// proof",

--- a/storage/fixtures/site.json
+++ b/storage/fixtures/site.json
@@ -23,7 +23,11 @@
 	},
 	"organization": {
 		"description": "Oullin is a boutique software engineering and architecture consultancy for startups and scale-ups navigating the AI era. AI architecture, modernisation, and resilient systems for regulated and high-trust environments.",
-		"sameAs": ["https://github.com/oullin"]
+		"sameAs": ["https://github.com/oullin"],
+		"founder": {
+			"name": "Gustavo Ocanto",
+			"url": "https://gocanto.sh"
+		}
 	},
 	"nav": {
 		"links": [

--- a/storage/fixtures/work-with-us-page.json
+++ b/storage/fixtures/work-with-us-page.json
@@ -39,8 +39,7 @@
 				"— Two 90-minute working sessions with the founding/engineering team"
 			],
 			"outcome": "A clear, honest answer to where AI fits in your stack — and an architectural plan that survives contact with production.",
-			"price": "From $8,000 · Fixed fee",
-			"cta": { "label": "START A CONVERSATION →", "to": "/contact" }
+			"cta": { "label": "More info", "to": "/contact" }
 		},
 		{
 			"label": "[ 02 ] Fractional AI Architect",
@@ -59,8 +58,7 @@
 				"— Quarterly roadmap refresh aligned to business goals"
 			],
 			"outcome": "Senior architectural oversight without a full-time hire. A team that gets better at building as the engagement runs.",
-			"price": "From $8,000/mo · 3-month minimum",
-			"cta": { "label": "START A CONVERSATION →", "to": "/contact" }
+			"cta": { "label": "More info", "to": "/contact" }
 		},
 		{
 			"label": "[ 03 ] Production Hardening",
@@ -79,8 +77,7 @@
 				"— 2-week async support window post-engagement"
 			],
 			"outcome": "AI features that hold under real conditions. Documentation your team owns. No dependency on us to keep it running.",
-			"price": "From $15,000 · Scoped after a paid discovery session ($2,500)",
-			"cta": { "label": "START A CONVERSATION →", "to": "/contact" }
+			"cta": { "label": "More info", "to": "/contact" }
 		},
 		{
 			"label": "[ 04 ] AI-Era Team Enablement",
@@ -97,8 +94,7 @@
 				"— A written playbook the team owns after we leave"
 			],
 			"outcome": "Engineers who can build with AI and review what it produces with real judgment. The capability stays in your team.",
-			"price": "From $6,000 · 4-week programme",
-			"cta": { "label": "START A CONVERSATION →", "to": "/contact" }
+			"cta": { "label": "More info", "to": "/contact" }
 		}
 	],
 	"faq": {

--- a/tests/pages/AboutPage.test.ts
+++ b/tests/pages/AboutPage.test.ts
@@ -75,7 +75,9 @@ describe('AboutPage', () => {
 		expect(wrapper.text()).toContain(aboutPageContent.sidebar.founder.copy);
 		expect(wrapper.text()).toContain(aboutPageContent.sidebar.proof.items[1]);
 		expect(wrapper.find('[data-testid="recommendation-partial"]').text()).toContain('Recommendations partial');
-		expect(wrapper.html()).toContain(aboutPageContent.sidebar.founder.linkUrl);
+		const founderLink = wrapper.find(`a[href="${aboutPageContent.sidebar.founder.linkUrl}"]`);
+		expect(founderLink.text()).toBe('Founder bio →');
+		expect(founderLink.attributes('rel')).toContain('me');
 	});
 
 	it('renders the about footer without the skills marquee band', async () => {

--- a/tests/pages/WorkWithUsPage.test.ts
+++ b/tests/pages/WorkWithUsPage.test.ts
@@ -28,9 +28,10 @@ describe('WorkWithUsPage', () => {
 		const moreInfoLinks = wrapper.findAll('a').filter((link) => link.text() === 'More info');
 
 		expect(moreInfoLinks).toHaveLength(workWithUsPageContent.engagements.length);
-		moreInfoLinks.forEach((link) => {
+		moreInfoLinks.forEach((link, index) => {
 			expect(link.attributes('to')).toBe('/contact');
+			expect(link.attributes('aria-label')).toBe(`More info about ${workWithUsPageContent.engagements[index]?.label}`);
 		});
-		expect(wrapper.text()).not.toMatch(/\$[\d,]+/);
+		expect(wrapper.text()).not.toMatch(/(?:[$€£]\s*\d[\d,.]*(?:[km])?|\b\d[\d,.]*(?:[km])?\s*(?:USD|EUR|GBP)\b)/i);
 	});
 });

--- a/tests/pages/WorkWithUsPage.test.ts
+++ b/tests/pages/WorkWithUsPage.test.ts
@@ -22,4 +22,15 @@ describe('WorkWithUsPage', () => {
 		expect(wrapper.text()).toContain(workWithUsPageContent.faq.items[0].question);
 		expect(wrapper.text()).toContain(workWithUsPageContent.cta.button.label);
 	});
+
+	it('replaces engagement prices with contact links', () => {
+		const wrapper = mount(WorkWithUsPage, { global });
+		const moreInfoLinks = wrapper.findAll('a').filter((link) => link.text() === 'More info');
+
+		expect(moreInfoLinks).toHaveLength(workWithUsPageContent.engagements.length);
+		moreInfoLinks.forEach((link) => {
+			expect(link.attributes('to')).toBe('/contact');
+		});
+		expect(wrapper.text()).not.toMatch(/\$[\d,]+/);
+	});
 });

--- a/tests/pages/WorkWithUsPage.test.ts
+++ b/tests/pages/WorkWithUsPage.test.ts
@@ -30,7 +30,7 @@ describe('WorkWithUsPage', () => {
 		expect(moreInfoLinks).toHaveLength(workWithUsPageContent.engagements.length);
 		moreInfoLinks.forEach((link, index) => {
 			expect(link.attributes('to')).toBe('/contact');
-			expect(link.attributes('aria-label')).toBe(`More info about ${workWithUsPageContent.engagements[index]?.label}`);
+			expect(link.attributes('aria-label')).toBe(`${workWithUsPageContent.engagements[index]?.cta.label} about ${workWithUsPageContent.engagements[index]?.label}`);
 		});
 		expect(wrapper.text()).not.toMatch(/(?:[$€£]\s*\d[\d,.]*(?:[km])?|\b\d[\d,.]*(?:[km])?\s*(?:USD|EUR|GBP)\b)/i);
 	});

--- a/tests/support/seo-content.test.ts
+++ b/tests/support/seo-content.test.ts
@@ -54,7 +54,13 @@ describe('SEO content fixtures', () => {
 			name: 'Gustavo Ocanto',
 			url: 'https://gocanto.sh',
 		});
-		expect(indexHtml).toContain('"url": "https://gocanto.sh"');
+
+		const jsonLdMatch = indexHtml.match(/<script[^>]*type="application\/ld\+json"[^>]*>([\s\S]*?)<\/script>/);
+		expect(jsonLdMatch?.[1]).toBeDefined();
+
+		const indexJsonLd = JSON.parse(jsonLdMatch?.[1] ?? '[]') as Array<Record<string, unknown>>;
+		const indexOrganization = indexJsonLd.find((entry) => entry['@type'] === 'Organization');
+		expect(indexOrganization?.founder).toEqual(ORGANIZATION_JSON_LD.founder);
 	});
 });
 

--- a/tests/support/seo-content.test.ts
+++ b/tests/support/seo-content.test.ts
@@ -9,6 +9,7 @@ import { siteContent } from '@/support/content.ts';
 import { termsAndPoliciesPageContent } from '@/support/content/terms-and-policies-page.ts';
 import { workWithUsPageContent } from '@/support/content/work-with-us-page.ts';
 import { writingPageContent } from '@/support/content/writing-page.ts';
+import { ORGANIZATION_JSON_LD } from '@/support/seo.ts';
 
 const indexHtml = readFileSync(resolve(process.cwd(), 'index.html'), 'utf8');
 const staleGustavoTitle = 'Gustavo Ocanto - Engineering, Leadership, Fintech & eCommerce | Software Engineer, Architect, AI , AI Architect & Manager';
@@ -45,6 +46,15 @@ describe('SEO content fixtures', () => {
 		expect(projectsPageContent.seo.description).toContain('resilient software delivery');
 		expect(writingPageContent.seo.description).toContain('engineering judgment');
 		expect(termsAndPoliciesPageContent.seo.description).toContain("Oullin's terms and policies");
+	});
+
+	it('connects the organization founder metadata to the canonical bio site', () => {
+		expect(ORGANIZATION_JSON_LD.founder).toEqual({
+			'@type': 'Person',
+			name: 'Gustavo Ocanto',
+			url: 'https://gocanto.sh',
+		});
+		expect(indexHtml).toContain('"url": "https://gocanto.sh"');
 	});
 });
 


### PR DESCRIPTION
## Summary

- remove displayed prices from all four engagement offerings
- replace each engagement action with a simple More info link to the contact page
- remove the obsolete price field from the content type
- add regression coverage for the contact links and absence of currency values
- point the About-page founder bio link to `https://gocanto.sh`
- add `rel="me"` identity metadata and founder `Person` structured data

## Why

Engagement pricing should no longer be published on the site, so visitors are directed to the contact page for more information. The founder bio and SEO metadata now use Gustavo Ocanto's canonical website.

## Validation

- `pnpm exec vitest run tests/pages/WorkWithUsPage.test.ts`
- `pnpm exec vitest run tests/pages/AboutPage.test.ts tests/support/seo-content.test.ts`
- `pnpm run lint` (passes with three existing unrelated warnings)
- `pnpm run build`
- Playwright verified all four links and navigation to `/contact`
- Playwright verified the rendered founder link, `rel="me"`, and JSON-LD URL


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Engagement cards now show “More info” contact links, with clearer details on what’s included and the expected outcome.
  - Added founder metadata to the site’s organisation info and structured data, and updated the founder bio link text and destination.
- **Bug Fixes**
  - Removed outdated engagement price displays and updated CTA presentation (including improved accessibility labelling).
- **Tests**
  - Added coverage for “More info” links, ensuring prices are no longer shown, and validating the new founder SEO metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->